### PR TITLE
support scope annotations

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -51,6 +51,10 @@ rule token = parse
   | "]" { RBRACKET }
   | "(" { LPAREN }
   | ")" { RPAREN }
+  | "{" { LBRACE }
+  | "}" { RBRACE }
+  | "," { COMMA }
+  | "..." { TRIPLE_DOT }
   | ":" { COLON }
   | "=" { EQUAL }
   | "<-" { LEFTARROW }

--- a/sourir.ml
+++ b/sourir.ml
@@ -1,11 +1,21 @@
 let () =
   match Sys.argv.(1) with
   | exception _ ->
-    Printf.eprintf 
+    Printf.eprintf
       "You should provide a Sourir file to parse as command-line argument.\n\
        Example: %s test.sou\n%!"
       Sys.executable_name;
     exit 1
   | path ->
-    (* TODO pretty-print the parsed file, then run it? *)
-    ignore (Parse.parse_file path)
+    let annotated_program = Parse.parse_file path in
+    begin match Scope.infer annotated_program with
+      | _scoped_program -> ()
+      | exception Scope.UndefinedVariable xs ->
+        begin match Scope.VarSet.elements xs with
+          | [x] -> Printf.eprintf "Error: Variable %s undefined.\n%!" x
+          | xs -> Printf.eprintf "Error: Variables {%s} undefined.\n%!"
+                    (String.concat ", " xs)
+        end;
+        exit 1
+    end;
+    ()


### PR DESCRIPTION
      { x, y, z } <instruction>
    
requires that exactly `{ x, y, z }` be available at this point in the
program. All other variables will be dropped from the environment.
    
      { x, y, ... } <instruction>
    
requires that at least those variables be available.

