### PR TITLE
factor out analysis algorithm from scope inference

### DIFF
--- a/analysis.ml
+++ b/analysis.ml
@@ -1,10 +1,10 @@
 open Instr
 
-let successors prog_at program pc =
+let successors program pc =
   let pc' = pc + 1 in
   let next = if pc' = Array.length program then [] else [pc'] in
-  let resolve = Instr.generic_resolve prog_at program in
-  match prog_at program pc with
+  let resolve = Instr.resolve program in
+  match program.(pc) with
   | Decl_const _
   | Decl_mut _
   | Assign _
@@ -30,14 +30,12 @@ module VarSet = Set.Make(Variable)
 
 let forward_analysis (init_state : 'a)
                      (merge : 'a -> 'a -> 'a option)
-                     (update : 'p -> 'a -> 'a)
-                     (program : 'p array)
-                     (prog_at : 'p array -> int -> Instr.instruction)
+                     (update : int -> 'a -> 'a)
+                     (program : program)
                      : 'a option array =
   let program_state = Array.map (fun _ -> ref None) program in
   let rec work = function
     | (in_state, pc) :: rest ->
-        let instr = program.(pc) in
         let cell = program_state.(pc) in
         let merged =
           match !cell with
@@ -47,8 +45,8 @@ let forward_analysis (init_state : 'a)
         | None -> work rest
         | Some merged ->
             cell := Some merged;
-            let updated = update instr merged in
-            let succs = successors prog_at program pc in
+            let updated = update pc merged in
+            let succs = successors program pc in
             let new_work = List.map (fun pc -> (updated, pc)) succs in
             work (new_work @ rest)
         end

--- a/analysis.ml
+++ b/analysis.ml
@@ -20,10 +20,10 @@ module VarSet = Set.Make(Variable)
 (* Perform forward analysis on some code
  *
  * init_state : Initial input state to instruction 0
- * merge      : current state * input state -> merge state if changed
- * update     : abstract instruction * input state -> output state
+ * merge      : current state -> input state -> merge state if changed
+ * update     : abstract instruction -> input state -> output state
  * program    : array of abstract instructions
- * prog_at    : program * index -> instruction at index
+ * prog_at    : program -> index -> instruction at index
  *
  * Returns an array of states for every instruction of the program.
  * Bottom is represented as None *)
@@ -35,8 +35,7 @@ let forward_analysis (init_state : 'a)
                      (prog_at : 'p array -> int -> Instr.instruction)
                      : 'a option array =
   let program_state = Array.map (fun _ -> ref None) program in
-  let rec work (worklist : ('a * int) list) : unit =
-    match worklist with
+  let rec work = function
     | (in_state, pc) :: rest ->
         let instr = program.(pc) in
         let cell = program_state.(pc) in

--- a/analysis.ml
+++ b/analysis.ml
@@ -1,0 +1,59 @@
+open Instr
+
+let successors prog_at program pc =
+  let pc' = pc + 1 in
+  let next = if pc' = Array.length program then [] else [pc'] in
+  let resolve = Instr.generic_resolve prog_at program in
+  match prog_at program pc with
+  | Decl_const _
+  | Decl_mut _
+  | Assign _
+  | Label _
+  | Comment _
+  | Print _ -> next
+  | Goto l | Invalidate (_, l, _) -> [resolve l]
+  | Branch (_e, l1, l2) -> [resolve l1; resolve l2]
+  | Stop -> []
+
+module VarSet = Set.Make(Variable)
+
+(* Perform forward analysis on some code
+ *
+ * init_state : Initial input state to instruction 0
+ * merge      : current state * input state -> merge state if changed
+ * update     : abstract instruction * input state -> output state
+ * program    : array of abstract instructions
+ * prog_at    : program * index -> instruction at index
+ *
+ * Returns an array of states for every instruction of the program.
+ * Bottom is represented as None *)
+
+let forward_analysis (init_state : 'a)
+                     (merge : 'a -> 'a -> 'a option)
+                     (update : 'p -> 'a -> 'a)
+                     (program : 'p array)
+                     (prog_at : 'p array -> int -> Instr.instruction)
+                     : 'a option array =
+  let program_state = Array.map (fun _ -> ref None) program in
+  let rec work (worklist : ('a * int) list) : unit =
+    match worklist with
+    | (in_state, pc) :: rest ->
+        let instr = program.(pc) in
+        let cell = program_state.(pc) in
+        let merged =
+          match !cell with
+          | None -> Some in_state
+          | Some cur_state -> merge cur_state in_state
+        in begin match merged with
+        | None -> work rest
+        | Some merged ->
+            cell := Some merged;
+            let updated = update instr merged in
+            let succs = successors prog_at program pc in
+            let new_work = List.map (fun pc -> (updated, pc)) succs in
+            work (new_work @ rest)
+        end
+    | [] -> ()
+  in
+  work [(init_state, 0)];
+  Array.map (fun r -> !r) program_state

--- a/analysis.ml
+++ b/analysis.ml
@@ -35,6 +35,7 @@ let forward_analysis (init_state : 'a)
                      : 'a option array =
   let program_state = Array.map (fun _ -> ref None) program in
   let rec work = function
+    | [] -> ()
     | (in_state, pc) :: rest ->
         let cell = program_state.(pc) in
         let merged =
@@ -50,7 +51,6 @@ let forward_analysis (init_state : 'a)
             let new_work = List.map (fun pc -> (updated, pc)) succs in
             work (new_work @ rest)
         end
-    | [] -> ()
   in
   work [(init_state, 0)];
-  Array.map (fun r -> !r) program_state
+  Array.map (!) program_state

--- a/disasm.ml
+++ b/disasm.ml
@@ -1,13 +1,13 @@
 open Instr
 
-let disassemble (prog : (Scope.scope_annotation option * Instr.instruction) array) =
+let disassemble (prog : Scope.annotated_program) =
   let lit_to_str lit =
     match lit with
     | Int i  -> string_of_int i
     | Bool b -> string_of_bool b
     | Nil    -> "nil"
   in
-  let dump_instr buf (instr_annot : (Scope.scope_annotation option * Instr.instruction)) =
+  let dump_instr buf instr annot =
     let pr = Printf.bprintf in
     let dump_expr exp =
       match exp with
@@ -17,29 +17,27 @@ let disassemble (prog : (Scope.scope_annotation option * Instr.instruction) arra
       | Op (Eq,   [a; b]) -> pr buf "(%s == %s)" a b
       | Op (_, _)         -> assert(false)
     in
-    match instr_annot with
-    | (annot, instr) ->
-        let str_from_vars vars = String.concat ", " (Scope.VarSet.elements vars) in
-        begin match annot with
-        | Some (Scope.Exact e)    -> pr buf "{%s} "      (str_from_vars e)
-        | Some (Scope.At_least e) -> pr buf "{%s, ...} " (str_from_vars e)
-        | None -> ()
-        end;
-        begin match instr with
-        | Decl_const (var, exp)           -> pr buf " const %s = " var; dump_expr exp
-        | Decl_mut (var, exp)             -> pr buf " mut %s = " var; dump_expr exp
-        | Assign (var, exp)               -> pr buf " %s <- " var; dump_expr exp
-        | Branch (exp, l1, l2)            -> pr buf " branch "; dump_expr exp; pr buf " %s %s" l1 l2
-        | Label label                     -> pr buf "%s:" label
-        | Goto label                      -> pr buf " goto %s" label
-        | Print exp                       -> pr buf " print "; dump_expr exp
-        | Invalidate (exp, l, vars)       -> pr buf " invalidate "; dump_expr exp;
-                                             pr buf " %s [%s]" l (String.concat ", " vars)
-        | Stop                            -> pr buf " stop"
-        | Comment str                     -> pr buf " #%s" str
-        end;
-        pr buf "\n"
+    let str_from_vars vars = String.concat ", " (Scope.VarSet.elements vars) in
+    begin match annot with
+    | Some (Scope.Exact e)    -> pr buf "{%s} "      (str_from_vars e)
+    | Some (Scope.At_least e) -> pr buf "{%s, ...} " (str_from_vars e)
+    | None -> ()
+    end;
+    begin match instr with
+    | Decl_const (var, exp)           -> pr buf " const %s = " var; dump_expr exp
+    | Decl_mut (var, exp)             -> pr buf " mut %s = " var; dump_expr exp
+    | Assign (var, exp)               -> pr buf " %s <- " var; dump_expr exp
+    | Branch (exp, l1, l2)            -> pr buf " branch "; dump_expr exp; pr buf " %s %s" l1 l2
+    | Label label                     -> pr buf "%s:" label
+    | Goto label                      -> pr buf " goto %s" label
+    | Print exp                       -> pr buf " print "; dump_expr exp
+    | Invalidate (exp, l, vars)       -> pr buf " invalidate "; dump_expr exp;
+                                         pr buf " %s [%s]" l (String.concat ", " vars)
+    | Stop                            -> pr buf " stop"
+    | Comment str                     -> pr buf " #%s" str
+    end;
+    pr buf "\n"
   in
   let b = Buffer.create 1024 in
-  Array.iter (dump_instr b) prog;
+  Array.iter2 (dump_instr b) (fst prog) (snd prog);
   Buffer.contents b

--- a/instr.ml
+++ b/instr.ml
@@ -55,14 +55,9 @@ type binding =
 
 exception Unbound_label of label
 
-let generic_resolve (at : 'p array -> int -> instruction) (code : 'p array) (label : string) =
+let resolve (code : program) (label : string) =
   let rec loop i =
     if i >= Array.length code then raise (Unbound_label label)
-    else if (at code i) = Label label then i
+    else if code.(i) = Label label then i
     else loop (i + 1)
   in loop 0
-
-let resolve (code : instruction array) (label : string) =
-  let resolve = generic_resolve (fun code pc -> code.(pc)) code in
-  resolve label
-

--- a/instr.ml
+++ b/instr.ml
@@ -55,10 +55,14 @@ type binding =
 
 exception Unbound_label of label
 
-let resolve code label =
+let generic_resolve (at : 'p array -> int -> instruction) (code : 'p array) (label : string) =
   let rec loop i =
     if i >= Array.length code then raise (Unbound_label label)
-    else if code.(i) = Label label then i
+    else if (at code i) = Label label then i
     else loop (i + 1)
   in loop 0
+
+let resolve (code : instruction array) (label : string) =
+  let resolve = generic_resolve (fun code pc -> code.(pc)) code in
+  resolve label
 

--- a/parse.ml
+++ b/parse.ml
@@ -4,11 +4,16 @@ let position {Lexing.pos_fname; pos_lnum; pos_cnum; pos_bol} =
   let character = pos_cnum - pos_bol in
   (file, line, character)
 
+let split_annotations program =
+  let annotations = Array.map fst program in
+  let instructions = Array.map snd program in
+  (instructions, annotations)
+
 let parse_string str =
   let lexbuf = Lexing.from_string str in
-  Parser.program Lexer.token lexbuf
+  split_annotations (Parser.program Lexer.token lexbuf)
 
-let parse_file path =
+let parse_file path : Scope.annotated_program =
   let chan = open_in path in
   let lexbuf =
     let open Lexing in
@@ -23,7 +28,7 @@ let parse_file path =
     lexbuf
   in
   match Parser.program Lexer.token lexbuf with
-  | program -> program
+  | program -> split_annotations program
   | exception (Lexer.Lexing_error invalid_input) ->
     let file, line, character = position lexbuf.Lexing.lex_curr_p in
     Printf.eprintf

--- a/sourir.ml
+++ b/sourir.ml
@@ -17,6 +17,6 @@ let () =
         end;
         exit 1
       | _scopes ->
-        let program = Array.map snd annotated_program in
+        let program = fst annotated_program in
         ignore (Eval.run_interactive program)
     end

--- a/sourir.mllib
+++ b/sourir.mllib
@@ -5,3 +5,4 @@ Parser
 Parse
 Eval
 Disasm
+Analysis

--- a/tests.ml
+++ b/tests.ml
@@ -207,7 +207,6 @@ let test_scope_1 test_var1 test_var2 =
   |]
 
 
-
 let infer_broken_scope program missing_vars = function() ->
      let test = function() -> ignore (Scope.infer program) in
      let expected = Scope.(UndefinedVariable (VarSet.of_list missing_vars)) in


### PR DESCRIPTION
This introduces a generic forward analysis function

The reason for this patch is to make it easier to write other analysis'.

As a nice side-effect it makes it even more apparent that scope inference closely follows abstract interpretation