### PR TITLE
Optimize find_origins

### DIFF
--- a/tests.ml
+++ b/tests.ml
@@ -306,6 +306,9 @@ let test_branch_pruning prog deopt =
   assert_equal res1.trace res2.trace;
   assert_equal res2.deopt (Some deopt)
 
+let assert_equal_sorted li1 li2 =
+  assert_equal (List.sort compare li1) (List.sort compare li2)
+
 let test_pred = fst (Parse.parse_string
 "l1:
   goto l2
@@ -318,14 +321,14 @@ let test_pred = fst (Parse.parse_string
 ")
 let do_test_pred = function () ->
   let pred = Analysis.predecessors test_pred in
-  assert_equal (pred 0) [3; 5; 7];
-  assert_equal (pred 1) [0];
-  assert_equal (pred 2) [5];
-  assert_equal (pred 3) [2];
-  assert_equal (pred 4) [1; 3];
-  assert_equal (pred 5) [4];
-  assert_equal (pred 6) [];
-  assert_equal (pred 7) []
+  assert_equal_sorted (pred 0) [3; 5; 7];
+  assert_equal_sorted (pred 1) [0];
+  assert_equal_sorted (pred 2) [5];
+  assert_equal_sorted (pred 3) [2];
+  assert_equal_sorted (pred 4) [1; 3];
+  assert_equal_sorted (pred 5) [4];
+  assert_equal_sorted (pred 6) [];
+  assert_equal_sorted (pred 7) []
 
 let suite =
   let open Assembler in

--- a/tests.ml
+++ b/tests.ml
@@ -321,6 +321,7 @@ let test_pred = fst (Parse.parse_string
 ")
 let do_test_pred = function () ->
   let pred = Analysis.predecessors test_pred in
+  let pred pc = pred.(pc) in
   assert_equal_sorted (pred 0) [3; 5; 7];
   assert_equal_sorted (pred 1) [0];
   assert_equal_sorted (pred 2) [5];

--- a/transform.ml
+++ b/transform.ml
@@ -1,12 +1,12 @@
 open Instr
 
 let remove_empty_jmp prog =
+  let pred = Analysis.predecessors prog in
   let rec remove_empty_jmp pc =
     let pc' = pc + 1 in
     if pc' = Array.length prog then [prog.(pc)] else
-      let pred = Analysis.predecessors prog in
       match (prog.(pc), prog.(pc')) with
-      | (Goto l1, Label l2) when l1 = l2 && List.length (pred pc') = 1 ->
+      | (Goto l1, Label l2) when l1 = l2 && List.length pred.(pc') = 1 ->
           remove_empty_jmp (pc+2)
       | (_, _) ->
           prog.(pc) :: remove_empty_jmp (pc')


### PR DESCRIPTION
The first commit keeps the two implementations in parallel and check that they return the same result.