### PR TITLE
Error messages

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -2,4 +2,4 @@ S .
 B _build
 B _build/src/sourir
 B _build/tests
-PKG oUnit
+PKG oUnit menhirLib

--- a/_tags
+++ b/_tags
@@ -1,3 +1,5 @@
+true: package(menhirLib)
 <tests.*>: package(oUnit)
+<parser.*>: menhir_table
 
 true: debug

--- a/lexer.mll
+++ b/lexer.mll
@@ -1,8 +1,7 @@
 {
-open Lexing
 open Parser
 
-exception Lexing_error of string
+exception Error of string * Lexing.position
 
 let keyword_table = [
   "const", CONST;
@@ -31,7 +30,7 @@ let comment_of_string str =
 
 let lexing_error lexbuf =
   let invalid_input = String.make 1 (Lexing.lexeme_char lexbuf 0) in
-  raise (Lexing_error invalid_input)
+  raise (Error (invalid_input, lexbuf.Lexing.lex_curr_p))
 }
 
 let int_literal = '-'? ['0'-'9'] ['0'-'9']*

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,23 +2,36 @@ open Ocamlbuild_plugin
 
 module Pack = Ocamlbuild_pack
 
+let menhir () =
+  if !Options.ocamlyacc = N then V"MENHIR" else !Options.ocamlyacc
+let menhir_tags mly =
+  tags_of_pathname mly ++"ocaml"++"parser"++"menhir"
+
 let menhir_produce_messages env build =
   let messages, mly = env "%.messages", env "%.mly" in
-  let menhir = if !Options.ocamlyacc = N then V"MENHIR" else !Options.ocamlyacc in
-  let menhir_tags = tags_of_pathname mly ++"ocaml"++"parser"++"menhir" in
   let open Pack in
   Ocaml_compiler.prepare_compile build mly;
-  Cmd(S[menhir; T menhir_tags; A "--list-errors"; P mly; Sh ">"; Px messages])
+  Cmd(S[menhir (); T (menhir_tags mly);
+        A "--list-errors"; P mly; Sh ">"; Px messages])
 
 let menhir_compile_messages env build =
   let mly = env "%.mly" in
   let messages = env "%.messages" in
   let target = env "%_messages.ml" in
-  let menhir = if !Options.ocamlyacc = N then V"MENHIR" else !Options.ocamlyacc in
-  let menhir_tags = tags_of_pathname mly ++"ocaml"++"parser"++"menhir" in
-  Cmd(S[menhir; T menhir_tags; P mly;
+  Cmd(S[menhir (); T (menhir_tags mly); P mly;
         A "--compile-errors"; P messages;
         Sh ">"; Px target])
+
+let menhir_update_messages env build =
+  let mly = env "%.mly" in
+  let messages = env "%.messages" in
+  let tmp = Filename.temp_file "menhir" ".messages" in
+  Seq [
+    Cmd(S[menhir (); T (menhir_tags mly); P mly;
+          A "--update-errors"; P messages;
+          Sh ">"; P tmp]);
+    Cmd(S[A "mv"; P tmp; P (Pathname.concat Pathname.pwd messages)]);
+  ]
 
 let _ = dispatch begin function
     | Before_options ->
@@ -26,8 +39,6 @@ let _ = dispatch begin function
       Options.use_menhir := true;
     | After_rules ->
       flag ["menhir"; "parser"; "menhir_table"] (A "--table");
-
-
       rule "menhir: .mly -> .messages"
         ~prod:"%.messages"
         ~deps:["%.mly"]
@@ -36,5 +47,9 @@ let _ = dispatch begin function
         ~prod:"%_messages.ml"
         ~deps:["%.mly"; "%.messages"]
         menhir_compile_messages;
+      rule "menhir: .mly & .messages -> .messages & .messages.update"
+        ~stamp:"%.messages.update"
+        ~deps:["%.mly"; "%.messages"]
+        menhir_update_messages;
     | _ -> ()
 end

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,0 +1,40 @@
+open Ocamlbuild_plugin
+
+module Pack = Ocamlbuild_pack
+
+let menhir_produce_messages env build =
+  let messages, mly = env "%.messages", env "%.mly" in
+  let menhir = if !Options.ocamlyacc = N then V"MENHIR" else !Options.ocamlyacc in
+  let menhir_tags = tags_of_pathname mly ++"ocaml"++"parser"++"menhir" in
+  let open Pack in
+  Ocaml_compiler.prepare_compile build mly;
+  Cmd(S[menhir; T menhir_tags; A "--list-errors"; P mly; Sh ">"; Px messages])
+
+let menhir_compile_messages env build =
+  let mly = env "%.mly" in
+  let messages = env "%.messages" in
+  let target = env "%_messages.ml" in
+  let menhir = if !Options.ocamlyacc = N then V"MENHIR" else !Options.ocamlyacc in
+  let menhir_tags = tags_of_pathname mly ++"ocaml"++"parser"++"menhir" in
+  Cmd(S[menhir; T menhir_tags; P mly;
+        A "--compile-errors"; P messages;
+        Sh ">"; Px target])
+
+let _ = dispatch begin function
+    | Before_options ->
+      Options.use_ocamlfind := true;
+      Options.use_menhir := true;
+    | After_rules ->
+      flag ["menhir"; "parser"; "menhir_table"] (A "--table");
+
+
+      rule "menhir: .mly -> .messages"
+        ~prod:"%.messages"
+        ~deps:["%.mly"]
+        menhir_produce_messages;
+      rule "menhir: .mly & .messages -> _messages.ml"
+        ~prod:"%_messages.ml"
+        ~deps:["%.mly"; "%.messages"]
+        menhir_compile_messages;
+    | _ -> ()
+end

--- a/parse.ml
+++ b/parse.ml
@@ -37,6 +37,17 @@ let parse_string str =
   let lexbuf = Lexing.from_string str in
   parse lexbuf
 
+let nth_line file line =
+  try
+    let input = open_in file in
+    for i = 1 to line - 1 do
+      ignore (input_line input)
+    done;
+    let result = input_line input in
+    close_in input;
+    Some result
+  with _ -> None
+
 let parse_file path : Scope.annotated_program =
   let chan = open_in path in
   let lexbuf =
@@ -66,6 +77,10 @@ let parse_file path : Scope.annotated_program =
       else sprintf "character %d" start_character in
     Printf.eprintf "File %S, %s, %s, parsing error:\n%!"
       file lines characters;
+    begin match nth_line file curr_line with
+      | None -> ()
+      | Some line -> Printf.eprintf "> %s\n" line;
+    end;
     begin match message with
     | None -> ()
     | Some error_message -> prerr_endline error_message
@@ -74,6 +89,10 @@ let parse_file path : Scope.annotated_program =
   | Lexer.Lexing_error invalid_input ->
     let file, line, character = position lexbuf.Lexing.lex_curr_p in
     Printf.eprintf
-      "File %S, line %d, character %d, lexing error:\nInvalid input %S\n%!"
-      file line character invalid_input;
+      "File %S, line %d, character %d, lexing error:\n" file line character;
+    begin match nth_line file line with
+      | None -> ()
+      | Some line -> Printf.eprintf "> %s\n" line;
+    end;
+    Printf.eprintf "Invalid input %S\n%!" invalid_input;
     exit 1

--- a/parse.mli
+++ b/parse.mli
@@ -1,0 +1,14 @@
+type parse_error =
+  | Lexing of string * Lexing.position
+  | Parsing of message option * Lexing.position * Lexing.position
+and message = string
+
+exception Error of parse_error
+(** The two functions below may raise this exception
+    -- and no other. *)
+
+val parse_string : string -> Scope.annotated_program
+val parse_file : string -> Scope.annotated_program
+
+val report_error : parse_error -> unit
+(** Prints a user-friendly error message on the standard error ouput *)

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 53.
+## Ends in an error in state: 54.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 53.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 51.
+## Ends in an error in state: 52.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,7 +43,7 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 49.
 ##
 ## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
 ##
@@ -57,7 +57,7 @@ example "(x + 1)", is now expected to construct a constant declaration
 
 program: CONST IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 48.
 ##
 ## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
 ##
@@ -71,7 +71,7 @@ Parsing an instruction, we parsed "const <var>" so far; the equal sign
 
 program: CONST TRIPLE_DOT 
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 47.
 ##
 ## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
 ##
@@ -85,7 +85,7 @@ example "x", is now expected to construct a constant declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 45.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +99,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 57.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,7 +113,7 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 44.
 ##
 ## label -> IDENTIFIER . [ COLON ]
 ## variable -> IDENTIFIER . [ LEFTARROW ]
@@ -128,7 +128,7 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER COMMA TRIPLE_DOT 
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 39.
 ##
 ## separated_nonempty_list(COMMA,variable) -> variable COMMA . separated_nonempty_list(COMMA,variable) [ RBRACKET ]
 ##
@@ -143,7 +143,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 38.
 ##
 ## separated_nonempty_list(COMMA,variable) -> variable . [ RBRACKET ]
 ## separated_nonempty_list(COMMA,variable) -> variable . COMMA separated_nonempty_list(COMMA,variable) [ RBRACKET ]
@@ -159,7 +159,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 37.
 ##
 ## instruction -> INVALIDATE expression label LBRACKET . loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -174,7 +174,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 36.
 ##
 ## instruction -> INVALIDATE expression label . LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -189,7 +189,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 33.
+## Ends in an error in state: 34.
 ##
 ## instruction -> INVALIDATE expression . label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -205,7 +205,7 @@ example "[x, y, z]".
 
 program: INVALIDATE TRIPLE_DOT 
 ##
-## Ends in an error in state: 32.
+## Ends in an error in state: 33.
 ##
 ## instruction -> INVALIDATE . expression label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -299,7 +299,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 31.
 ##
 ## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
 ##
@@ -313,7 +313,7 @@ construct a constant mutable instruction "mut <var> = <expr>".
 
 program: MUT IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 29.
+## Ends in an error in state: 30.
 ##
 ## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
 ##
@@ -327,7 +327,7 @@ instruction "mut <var> = <expr>".
 
 program: MUT TRIPLE_DOT 
 ##
-## Ends in an error in state: 28.
+## Ends in an error in state: 29.
 ##
 ## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
 ##
@@ -342,12 +342,12 @@ declaration
 
 program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 21.
+## Ends in an error in state: 24.
 ##
-## expression -> LPAREN variable infixop variable . RPAREN [ NEWLINE IDENTIFIER ]
+## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ NEWLINE IDENTIFIER ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN variable infixop variable 
+## LPAREN simple_expression infixop simple_expression 
 ##
 
 Parsing an expression, we parsed "( <arg> <op> <arg>" so far;
@@ -355,12 +355,12 @@ a closing parenthesis ")" is now expected.
 
 program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
 ##
-## Ends in an error in state: 20.
+## Ends in an error in state: 23.
 ##
-## expression -> LPAREN variable infixop . variable RPAREN [ NEWLINE IDENTIFIER ]
+## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN variable infixop 
+## LPAREN simple_expression infixop 
 ##
 
 Parsing an expression, we parsed "( <arg> <op>" so far; an argument
@@ -369,12 +369,12 @@ Parsing an expression, we parsed "( <arg> <op>" so far; an argument
 
 program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 16.
+## Ends in an error in state: 19.
 ##
-## expression -> LPAREN variable . infixop variable RPAREN [ NEWLINE IDENTIFIER ]
+## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN variable 
+## LPAREN simple_expression 
 ##
 
 Parsing an expression, we parsed "( <arg>" so far; an operator such as
@@ -385,7 +385,7 @@ program: PRINT LPAREN TRIPLE_DOT
 ##
 ## Ends in an error in state: 15.
 ##
-## expression -> LPAREN . variable infixop variable RPAREN [ NEWLINE IDENTIFIER ]
+## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN 
@@ -428,7 +428,7 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 66.
 ##
 ## list(instruction_line) -> instruction_line . list(instruction_line) [ EOF ]
 ##
@@ -441,7 +441,7 @@ instruction on the next line, or the end of the file.
 
 program: STOP TRIPLE_DOT 
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 61.
 ##
 ## instruction_line -> scope_annotation instruction . NEWLINE [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
 ##

--- a/parser.messages
+++ b/parser.messages
@@ -1,0 +1,468 @@
+program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 53.
+##
+## instruction -> BRANCH expression label . label [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## BRANCH expression label 
+##
+
+Parsing an instruction, we parsed "branch <expr> <label>" so far;
+a label, for example "foo", is now expected to construct a branch
+instruction
+"branch <expr> <label> <label>".
+
+program: BRANCH NIL TRIPLE_DOT 
+##
+## Ends in an error in state: 52.
+##
+## instruction -> BRANCH expression . label label [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## BRANCH expression 
+##
+
+Parsing an instruction, we parsed "branch <expr>" so far; a label, for
+example "foo", is now expected to construct a branch instruction
+"branch <expr> <label> <label>".
+
+program: BRANCH TRIPLE_DOT 
+##
+## Ends in an error in state: 51.
+##
+## instruction -> BRANCH . expression label label [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## BRANCH 
+##
+
+Parsing an instruction, we parsed "branch" so far; an expression, for
+example "(x == 2)", is now expected to construct a branch instruction
+"branch <expr> <label> <label>".
+
+program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
+##
+## Ends in an error in state: 48.
+##
+## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## CONST variable EQUAL 
+##
+
+Parsing an instruction, we parsed "const <var> =" so far; an expression, for
+example "(x + 1)", is now expected to construct a constant declaration
+"const <var> = <expr>".
+
+program: CONST IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 47.
+##
+## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## CONST variable 
+##
+
+Parsing an instruction, we parsed "const <var>" so far; the equal sign
+"=" is now expected to construct a constant declaration
+"const <var> = <expr>".
+
+program: CONST TRIPLE_DOT 
+##
+## Ends in an error in state: 46.
+##
+## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## CONST 
+##
+
+Parsing an instruction, we parsed "const" so far; a variable, for
+example "x", is now expected to construct a constant declaration
+"const <var> = <expr>".
+
+program: GOTO TRIPLE_DOT 
+##
+## Ends in an error in state: 44.
+##
+## instruction -> GOTO . label [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## GOTO 
+##
+
+Parsing an instruction, we parsed "goto" so far; a label, for example
+"foo", is now expected to construct a goto instruction
+"goto <label>".
+
+program: IDENTIFIER LEFTARROW TRIPLE_DOT 
+##
+## Ends in an error in state: 56.
+##
+## instruction -> variable LEFTARROW . expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## variable LEFTARROW 
+##
+
+Parsing an instruction, we parsed "<var> <-" so far; an expression,
+for example "(x + 1)", is now expected to construct an assignment
+"<var> <- <expression>".
+
+program: IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 43.
+##
+## label -> IDENTIFIER . [ COLON ]
+## variable -> IDENTIFIER . [ LEFTARROW ]
+##
+## The known suffix of the stack is as follows:
+## IDENTIFIER 
+##
+
+Parsing an instruction, we parsed an identifier so far (variable or label). 
+- if this is a label declaration, we expect a semicolon: "<label>:"
+- if this is an assignment, we expect a left arrow: "<var> <- <expression>"
+
+program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER COMMA TRIPLE_DOT 
+##
+## Ends in an error in state: 38.
+##
+## separated_nonempty_list(COMMA,variable) -> variable COMMA . separated_nonempty_list(COMMA,variable) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## variable COMMA 
+##
+
+Parsing the variables of an invalidate instruction of the form
+"invalidate <expr> <label> <variables>", the variables should be
+a comma-separated list of identifiers, between square brackets, for
+example "[x, y, z]".
+
+program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 37.
+##
+## separated_nonempty_list(COMMA,variable) -> variable . [ RBRACKET ]
+## separated_nonempty_list(COMMA,variable) -> variable . COMMA separated_nonempty_list(COMMA,variable) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## variable 
+##
+
+Parsing the variables of an invalidate instruction of the form
+"invalidate <expr> <label> <variables>", the variables should be
+a comma-separated list of identifiers, between square brackets, for
+example "[x, y, z]".
+
+program: INVALIDATE NIL IDENTIFIER LBRACKET TRIPLE_DOT 
+##
+## Ends in an error in state: 36.
+##
+## instruction -> INVALIDATE expression label LBRACKET . loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## INVALIDATE expression label LBRACKET 
+##
+
+Parsing the variables of an invalidate instruction of the form
+"invalidate <expr> <label> <variables>", the variables should be
+a comma-separated list of identifiers, between square brackets, for
+example "[x, y, z]".
+
+program: INVALIDATE NIL IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 35.
+##
+## instruction -> INVALIDATE expression label . LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## INVALIDATE expression label 
+##
+
+Parsing an invalidate instruction, we parsed "invalidate <expr> <label>",
+and are now expecting the variables to preserve during invalidation,
+as a comma-separated list of identifiers, between square brackets, for
+example "[x, y, z]".
+
+program: INVALIDATE NIL TRIPLE_DOT 
+##
+## Ends in an error in state: 33.
+##
+## instruction -> INVALIDATE expression . label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## INVALIDATE expression 
+##
+
+Parsing an invalidate instruction, we parsed "invalidate <expr>", and
+are now expecting a label, for example "foo". The complete instruction
+syntax is "invalidate <expr> <label> <variables>", where "<variables>"
+is a comma-separated list of identifiers, between square brackets, for
+example "[x, y, z]".
+
+program: INVALIDATE TRIPLE_DOT 
+##
+## Ends in an error in state: 32.
+##
+## instruction -> INVALIDATE . expression label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## INVALIDATE 
+##
+
+Parsing an invalidate instruction, we parsed "invalidate", and are now
+expecting an expression, for example "(x + 1)". The complete
+instruction syntax is "invalidate <expr> <label> <variables>", where
+"<variables>" is a comma-separated list of identifiers, between square
+brackets, for example "[x, y, z]".
+
+program: LBRACE IDENTIFIER COMMA STOP 
+##
+## Ends in an error in state: 5.
+##
+## scope -> variable COMMA . scope [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## variable COMMA 
+##
+
+Parsing a scope annotation, we expect a comma-separated list of
+variables between curly brackets, for example "{ x, y }", the last
+element possibly being "...", for example "{ x, y, ...}". ("..." means
+that we are not restricting the instruction to use only the variables
+listed, we are only asking that at least those variables be present in
+scope.)
+
+program: LBRACE IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 4.
+##
+## scope -> variable . COMMA scope [ RBRACE ]
+## scope -> variable . [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## variable 
+##
+
+Parsing a scope annotation, we expect a comma-separated list of
+variables between curly brackets, for example "{ x, y }", the last
+element possibly being "...", for example "{ x, y, ...}". ("..." means
+that we are not restricting the instruction to use only the variables
+listed, we are only asking that at least those variables be present in
+scope.)
+
+program: LBRACE STOP 
+##
+## Ends in an error in state: 1.
+##
+## scope_annotation -> LBRACE . scope RBRACE [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
+##
+## The known suffix of the stack is as follows:
+## LBRACE 
+##
+
+Parsing a scope annotation, we expect a comma-separated list of
+variables between curly brackets, for example "{ x, y }", the last
+element possibly being "...", for example "{ x, y, ...}". ("..." means
+that we are not restricting the instruction to use only the variables
+listed, we are only asking that at least those variables be present in
+scope.)
+
+program: LBRACE TRIPLE_DOT RBRACE BOOL 
+##
+## Ends in an error in state: 9.
+##
+## instruction_line -> scope_annotation . instruction NEWLINE [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
+##
+## The known suffix of the stack is as follows:
+## scope_annotation 
+##
+
+We parsed a scope annotation, and we now expect an instruction
+followed by a line break.
+
+program: LBRACE TRIPLE_DOT TRIPLE_DOT 
+##
+## Ends in an error in state: 7.
+##
+## scope_annotation -> LBRACE scope . RBRACE [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
+##
+## The known suffix of the stack is as follows:
+## LBRACE scope 
+##
+
+In a scope annotation, "..." should be the last item. "{ x, ... }" or
+"{ ... }" are valid, but "{ ..., x }" is not.
+
+program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
+##
+## Ends in an error in state: 30.
+##
+## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## MUT variable EQUAL 
+##
+
+Parsing a mutable declaration instruction, we parsed "mut <var> =" so
+far; an expression is now expected, for example "(x + 1)", to
+construct a constant mutable instruction "mut <var> = <expr>".
+
+program: MUT IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 29.
+##
+## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## MUT variable 
+##
+
+Parsing a mutable declaration instruction, we parsed "mut <var>" so
+far; an equal sign "=" is now expected to construct a constant mutable
+instruction "mut <var> = <expr>".
+
+program: MUT TRIPLE_DOT 
+##
+## Ends in an error in state: 28.
+##
+## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## MUT 
+##
+
+Parsing an instruction, we parsed "mut" so far; a variable, for
+example "x", is now expected to construct a mutable variable
+declaration
+"mut <var> = <expr>".
+
+program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 21.
+##
+## expression -> LPAREN variable infixop variable . RPAREN [ NEWLINE IDENTIFIER ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN variable infixop variable 
+##
+
+Parsing an expression, we parsed "( <arg> <op> <arg>" so far;
+a closing parenthesis ")" is now expected.
+
+program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
+##
+## Ends in an error in state: 20.
+##
+## expression -> LPAREN variable infixop . variable RPAREN [ NEWLINE IDENTIFIER ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN variable infixop 
+##
+
+Parsing an expression, we parsed "( <arg> <op>" so far; an argument
+(variable or literal value) is now expected to construct an expression
+"( <arg> <op> <arg> )".
+
+program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
+##
+## Ends in an error in state: 16.
+##
+## expression -> LPAREN variable . infixop variable RPAREN [ NEWLINE IDENTIFIER ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN variable 
+##
+
+Parsing an expression, we parsed "( <arg>" so far; an operator such as
+"+", "==" or "!=" is now expected to construct an expression
+"( <var> <op> <var> )".
+
+program: PRINT LPAREN TRIPLE_DOT 
+##
+## Ends in an error in state: 15.
+##
+## expression -> LPAREN . variable infixop variable RPAREN [ NEWLINE IDENTIFIER ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN 
+##
+
+Parsing an expression, we parsed "(" so far; an argument (variable or
+literal value) is now expected to construct an expression
+"( <arg> <op> <arg> )".
+
+program: PRINT TRIPLE_DOT 
+##
+## Ends in an error in state: 13.
+##
+## instruction -> PRINT . expression [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## PRINT 
+##
+
+Parsing an instruction, we parsed "print" so far;
+an expression, for example "(x + 1)", is now expected
+to construct a print instruction
+"print <expr>".
+
+program: READ TRIPLE_DOT 
+##
+## Ends in an error in state: 11.
+##
+## instruction -> READ . variable [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## READ 
+##
+
+Parsing an instruction, we parsed "read" so far;
+a variable, for example "x", is now expected
+to construct a read assignment
+"read <var>".
+Note that the variable needs to have been declared as mutable first.
+
+program: STOP NEWLINE TRIPLE_DOT 
+##
+## Ends in an error in state: 65.
+##
+## list(instruction_line) -> instruction_line . list(instruction_line) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## instruction_line 
+##
+
+We parsed a complete instruction line, and are now inspecting a valid
+instruction on the next line, or the end of the file.
+
+program: STOP TRIPLE_DOT 
+##
+## Ends in an error in state: 60.
+##
+## instruction_line -> scope_annotation instruction . NEWLINE [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
+##
+## The known suffix of the stack is as follows:
+## scope_annotation instruction 
+##
+
+We parsed an instruction, and are now expecting a newline to complete
+the instruction line -- even if this is the last instruction, it
+should be followed by a line break.
+
+program: TRIPLE_DOT 
+##
+## Ends in an error in state: 0.
+##
+## program' -> . program [ # ]
+##
+## The known suffix of the stack is as follows:
+## 
+##
+
+We parsed a correct program so far; extra instructions, or the end of
+the file, are now expected.
+

--- a/parser.mly
+++ b/parser.mly
@@ -10,7 +10,7 @@
 %token NEWLINE
 %token EOF
 
-%start<(Scope.scope_annotation option * Instr.instruction) array> program
+%start<Scope.annotated_program> program
 
 %{ open Instr
 
@@ -25,7 +25,12 @@ let scope_annotation (mode, xs) =
 %%
 
 program:
-| prog=list(instruction_line) EOF { Array.of_list prog }
+| prog=list(instruction_line) EOF
+  {
+    let annotations, instructions = List.split prog in
+    (Array.of_list instructions,
+     Array.of_list annotations)
+  }
 
 instruction_line:
 | a=scope_annotation i=instruction NEWLINE { (a, i) }

--- a/sourir.ml
+++ b/sourir.ml
@@ -7,7 +7,12 @@ let () =
       Sys.executable_name;
     exit 1
   | path ->
-    let annotated_program = Parse.parse_file path in
+    let annotated_program =
+      try Parse.parse_file path
+      with Parse.Error error ->
+        Parse.report_error error;
+        exit 2
+    in
     begin match Scope.infer annotated_program with
       | exception Scope.UndefinedVariable xs ->
         begin match Instr.VarSet.elements xs with

--- a/tests.ml
+++ b/tests.ml
@@ -160,21 +160,27 @@ let test_broken_scope_3 =
     print x;
   |]
 
-let test_broken_scope_4 = Parse.parse_string
+let parse_test str =
+  try Parse.parse_string str
+  with Parse.Error error ->
+    Parse.report_error error;
+    exit 2
+
+let test_broken_scope_4 = parse_test
 "mut x = 0
 mut y = 0
 {x} mut z = false
 z <- (x == y)
 "
 
-let test_broken_scope_4_fixed = Parse.parse_string
+let test_broken_scope_4_fixed = parse_test
 "mut x = 0
 mut y = 0
 {x, ...} mut z = false
 z <- (x == y)
 "
 
-let test_broken_scope_5 = Parse.parse_string
+let test_broken_scope_5 = parse_test
 "mut x = 0
 mut y = 0
 {w, ...} mut z = false
@@ -235,7 +241,7 @@ let test_disasm_parse prog = function() ->
   let prog2 = Parse.parse_string disasm1 in
   assert_equal prog prog2
 
-let test_branch = Parse.parse_string
+let test_branch = parse_test
 "mut x = 9
  mut y = 10
  mut r = 1
@@ -264,7 +270,7 @@ let test_branch_pruned = " mut x = 9
  stop
 "
 
-let test_double_loop = Parse.parse_string
+let test_double_loop = parse_test
 "mut i = 0
  mut sum = 0
  const limit = 4
@@ -307,7 +313,7 @@ let test_branch_pruning prog deopt =
 let assert_equal_sorted li1 li2 =
   assert_equal (List.sort compare li1) (List.sort compare li2)
 
-let test_pred = fst (Parse.parse_string
+let test_pred = fst (parse_test
 "l1:
   goto l2
  l3:
@@ -329,7 +335,7 @@ let do_test_pred = function () ->
   assert_equal_sorted (pred 6) [];
   assert_equal_sorted (pred 7) []
 
-let test_df = fst (Parse.parse_string
+let test_df = fst (parse_test
 "mut a = 1
  mut b = 2
  mut d = (a+b)


### PR DESCRIPTION
The way the error messages are obtained is by asking the parser generator for the list of its error states (and the inputs that lead it there, in a sense), and writing a message for each different case by hand. There are 32 error states in the current grammar, so writing 32 messages was a tad tedious, but then I got lost on the green line tonight so I had plenty of time on my hands.

The plumbing parts where I obtain the automaton error state number is admittedly rather arcane, as well as the build-system plumbing to obtain the error state information, compile the hand-written messages to an OCaml function, and update the messages file when the grammar change. But I think the result is relatively neat:

```
File "test.sou", line 3, characters 8-13, parsing error:
>   const limit 10
Parsing an instruction, we parsed "const <var>" so far; the equal sign
"=" is now expected to construct a constant declaration
"const <var> = <expr>".
```

```
File "test.sou", line 6, characters 0-9, parsing error:
> loop_body
Parsing an instruction, we parsed an identifier so far (variable or label). 
- if this is a label declaration, we expect a semicolon: "<label>:"
- if this is an assignment, we expect a left arrow: "<var> <- <expression>"
```

```
File "test.sou", line 9, characters 10-11, parsing error:
>   i <- (i + (1 + 2))
Parsing an expression, we parsed "( <arg> <op>" so far; an argument
(variable or literal value) is now expected to construct an expression
"( <arg> <op> <arg> )".
```

```
File "test.sou", line 9, characters 12-13, parsing error:
>   i <- (i + 1 + 2)
Parsing an expression, we parsed "( <arg> <op> <arg>" so far;
a closing parenthesis ")" is now expected.
```