### PR TITLE
get rid of fragile exhaustive pattern matches

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,3 +1,10 @@
 <tests.*>: package(oUnit)
 
 true: debug
+
+# fragile pattern matching
+true: warn(+4)
+
+# the code produced from parser.mly by the parser generator may
+# contain fragile pattern matches, we just disable the warning for them.
+<parser.*>: -warn(+4)

--- a/disasm.ml
+++ b/disasm.ml
@@ -13,7 +13,7 @@ let disassemble_annotated (prog : Scope.annotated_program) =
       | Op (Plus, [a; b]) -> pr buf "(%a + %a)" simple a simple b
       | Op (Neq,  [a; b]) -> pr buf "(%a != %a)" simple a simple b
       | Op (Eq,   [a; b]) -> pr buf "(%a == %a)" simple a simple b
-      | Op (_, _)         -> assert(false)
+      | Op ((Plus | Neq | Eq), _)         -> assert(false)
     in
     let str_from_vars vars = String.concat ", " (Instr.VarSet.elements vars) in
     begin match annot with

--- a/eval.ml
+++ b/eval.ml
@@ -74,7 +74,7 @@ let litteral_eq (lit1 : litteral) (lit2 : litteral) =
 let litteral_plus (lit1 : litteral) (lit2 : litteral) =
   match lit1, lit2 with
   | Int n1, Int n2 -> n1 + n2
-  | x1, x2 ->
+  | (Int _ | Nil | Bool _) as x1, x2 ->
       let expected = (Int, Int) in
       let received = litteral_type x1, litteral_type x2 in
       raise (ProductType_error { expected; received })
@@ -95,20 +95,20 @@ let rec eval heap env = function
     | Eq, [v1; v2] -> Lit (Bool (value_eq v1 v2))
     | Neq, [v1; v2] -> Lit (Bool (value_neq v1 v2))
     | Plus, [v1; v2] -> Lit (Int (value_plus v1 v2))
-    | op, _vs -> raise (Arity_error op)
+    | (Eq | Neq | Plus), _vs -> raise (Arity_error op)
     end
 
 let get_int (Lit lit : value) =
   match lit with
   | Int n -> n
-  | other ->
+  | (Nil | Bool _) as other ->
      let expected, received = Int, litteral_type other in
      raise (Type_error { expected; received })
 
 let get_bool (Lit lit : value) =
   match lit with
   | Bool b -> b
-  | other ->
+  | (Nil | Int _) as other ->
      let expected, received = Bool, litteral_type other in
      raise (Type_error { expected; received })
 


### PR DESCRIPTION
A pattern-matching is fragile when it is exhaustive and will remain
exhaustive even after new constructors are added to the matched
datatype. Getting rid of fragile exhaustive patterns means that we
know for sure that, when adding a new constructor (for example
a new instruction), the compiler will warn us about all parts of the
code that need to be updated. Consider for example:

    match exp with
    | Simple e          -> simple buf e
    | Op (Plus, [a; b]) -> pr buf "(%a + %a)" simple a simple b
    | Op (Neq,  [a; b]) -> pr buf "(%a != %a)" simple a simple b
    | Op (Eq,   [a; b]) -> pr buf "(%a == %a)" simple a simple b
    | Op (_, _)         -> assert(false)

This code is a bit dangerous because, once we add a new primitive
operator, it will compile just fine and starts assert-faulting at
runtime. Enabling the warning "4" (done by passing "warn(+4)" in
_tags) makes sure that this pattern-matching warns, and that we
replace it by the better version

    match exp with
    | Simple e          -> simple buf e
    | Op (Plus, [a; b]) -> pr buf "(%a + %a)" simple a simple b
    | Op (Neq,  [a; b]) -> pr buf "(%a != %a)" simple a simple b
    | Op (Eq,   [a; b]) -> pr buf "(%a == %a)" simple a simple b
    | Op ((Plus | Neq | Eq), _) -> assert(false)

that will warn us that it needs to be updated on each new instruction.

On the contrary, sometimes we really want to have a fragile pattern
(which is why this warning is not set by default). Consider:

    let rec kill_branch pc =
      if pc = Array.length prog then [Stop] else
      match scope.(pc) with
      | Scope.Dead -> assert(false)
      | Scope.Scope scope ->
          begin match prog.(pc) with
          | Branch (exp, l1, l2) ->
              let vars = Instr.VarSet.elements scope in
              Invalidate (exp, deopt_label l2, vars) ::
                Goto l1 ::
                  kill_branch (pc+1)
          | i ->
              i :: kill_branch (pc+1)
          end

In this case, the intent of the code is really to match only on the
Branch instruction, and leave all others unchanged. (One could argue
that another variant of the Branch instruction that would also need to
be handled here could be added in the future, but I'm not this careful
yet.) The solution to silence the warning locally is to use OCaml's
attributes, whose syntax is [@name payload], where the payload is any
syntactically valid OCaml expression. Here we use the @warning
attribute with the payloda "-4", which disables the warning number 4:

    begin match[@warning "-4"] prog.(pc) with
    | Branch (exp, l1, l2) ->
        let vars = Instr.VarSet.elements scope in
        Invalidate (exp, deopt_label l2, vars) ::
          Goto l1 ::
            kill_branch (pc+1)
    | i ->
        i :: kill_branch (pc+1)
    end

Having to use a warning number instead of a meaningful name is
unfortunate (it's one of things I'd like to improve in OCaml when
I have time someday), but the list of warnings and their number is
provided by the command `ocamlc -warn-help`.