### PR TITLE
Parse newlines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,16 @@ test_examples: sourir
 clean:
 	ocamlbuild -clean
 
+# The parser.messages file is maintained semi-automatically: a human
+# should maintain the error messages, but the parser generators update
+# the error state numbers and the example of token inputs that lead to
+# those. After changing the parser you should manually build this
+# target and inspect the change to the .messages file; if a new error
+# state appears, you should add an error message for it.
+update-parser-messages:
+	ocamlbuild parser.messages.update
+	cp _build/parser.messages parser.messages
+
 install-deps:
 	opam pin add sourir . --no-action # tell opam about a local "sourir" package
 	opam install --deps-only sourir # then install its dependencies

--- a/examples/sum.sou
+++ b/examples/sum.sou
@@ -1,6 +1,7 @@
   mut i = 0
   mut sum = 0
   const limit = 10
+
 loop:
   branch (i == limit) continue loop_body
 loop_body:
@@ -8,5 +9,7 @@ loop_body:
   sum <- (sum + i)
   i <- (i + 1)
   goto loop
+
+{sum}
 continue:
   print sum

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -30,7 +30,7 @@ let menhir_update_messages env build =
     Cmd(S[menhir (); T (menhir_tags mly); P mly;
           A "--update-errors"; P messages;
           Sh ">"; P tmp]);
-    Cmd(S[A "mv"; P tmp; P (Pathname.concat Pathname.pwd messages)]);
+    Cmd(S[A "mv"; P tmp; P messages]);
   ]
 
 let _ = dispatch begin function

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 60.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 53.
+## Ends in an error in state: 59.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 58.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,7 +43,7 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 49.
+## Ends in an error in state: 55.
 ##
 ## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
 ##
@@ -57,7 +57,7 @@ example "(x + 1)", is now expected to construct a constant declaration
 
 program: CONST IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 54.
 ##
 ## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
 ##
@@ -71,7 +71,7 @@ Parsing an instruction, we parsed "const <var>" so far; the equal sign
 
 program: CONST TRIPLE_DOT 
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 53.
 ##
 ## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
 ##
@@ -85,7 +85,7 @@ example "x", is now expected to construct a constant declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 51.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +99,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 63.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,7 +113,7 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 50.
 ##
 ## label -> IDENTIFIER . [ COLON ]
 ## variable -> IDENTIFIER . [ LEFTARROW ]
@@ -128,7 +128,7 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER COMMA TRIPLE_DOT 
 ##
-## Ends in an error in state: 39.
+## Ends in an error in state: 45.
 ##
 ## separated_nonempty_list(COMMA,variable) -> variable COMMA . separated_nonempty_list(COMMA,variable) [ RBRACKET ]
 ##
@@ -143,7 +143,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 44.
 ##
 ## separated_nonempty_list(COMMA,variable) -> variable . [ RBRACKET ]
 ## separated_nonempty_list(COMMA,variable) -> variable . COMMA separated_nonempty_list(COMMA,variable) [ RBRACKET ]
@@ -159,7 +159,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 43.
 ##
 ## instruction -> INVALIDATE expression label LBRACKET . loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -174,7 +174,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 42.
 ##
 ## instruction -> INVALIDATE expression label . LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -189,7 +189,7 @@ example "[x, y, z]".
 
 program: INVALIDATE NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 34.
+## Ends in an error in state: 40.
 ##
 ## instruction -> INVALIDATE expression . label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -205,7 +205,7 @@ example "[x, y, z]".
 
 program: INVALIDATE TRIPLE_DOT 
 ##
-## Ends in an error in state: 33.
+## Ends in an error in state: 39.
 ##
 ## instruction -> INVALIDATE . expression label LBRACKET loption(separated_nonempty_list(COMMA,variable)) RBRACKET [ NEWLINE ]
 ##
@@ -221,7 +221,7 @@ brackets, for example "[x, y, z]".
 
 program: LBRACE IDENTIFIER COMMA STOP 
 ##
-## Ends in an error in state: 5.
+## Ends in an error in state: 9.
 ##
 ## scope -> variable COMMA . scope [ RBRACE ]
 ##
@@ -238,7 +238,7 @@ scope.)
 
 program: LBRACE IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 4.
+## Ends in an error in state: 8.
 ##
 ## scope -> variable . COMMA scope [ RBRACE ]
 ## scope -> variable . [ RBRACE ]
@@ -256,9 +256,9 @@ scope.)
 
 program: LBRACE STOP 
 ##
-## Ends in an error in state: 1.
+## Ends in an error in state: 5.
 ##
-## scope_annotation -> LBRACE . scope RBRACE [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
+## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE 
@@ -273,12 +273,12 @@ scope.)
 
 program: LBRACE TRIPLE_DOT RBRACE BOOL 
 ##
-## Ends in an error in state: 9.
+## Ends in an error in state: 12.
 ##
-## instruction_line -> scope_annotation . instruction NEWLINE [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
+## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
-## scope_annotation 
+## LBRACE scope RBRACE 
 ##
 
 We parsed a scope annotation, and we now expect an instruction
@@ -286,9 +286,9 @@ followed by a line break.
 
 program: LBRACE TRIPLE_DOT TRIPLE_DOT 
 ##
-## Ends in an error in state: 7.
+## Ends in an error in state: 11.
 ##
-## scope_annotation -> LBRACE scope . RBRACE [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
+## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ STOP READ PRINT MUT INVALIDATE IDENTIFIER GOTO CONST COMMENT BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope 
@@ -299,7 +299,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 31.
+## Ends in an error in state: 37.
 ##
 ## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
 ##
@@ -313,7 +313,7 @@ construct a constant mutable instruction "mut <var> = <expr>".
 
 program: MUT IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 36.
 ##
 ## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
 ##
@@ -327,7 +327,7 @@ instruction "mut <var> = <expr>".
 
 program: MUT TRIPLE_DOT 
 ##
-## Ends in an error in state: 29.
+## Ends in an error in state: 35.
 ##
 ## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
 ##
@@ -342,7 +342,7 @@ declaration
 
 program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 24.
+## Ends in an error in state: 30.
 ##
 ## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ NEWLINE IDENTIFIER ]
 ##
@@ -355,7 +355,7 @@ a closing parenthesis ")" is now expected.
 
 program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
 ##
-## Ends in an error in state: 23.
+## Ends in an error in state: 29.
 ##
 ## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
@@ -369,7 +369,7 @@ Parsing an expression, we parsed "( <arg> <op>" so far; an argument
 
 program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 19.
+## Ends in an error in state: 25.
 ##
 ## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
@@ -383,7 +383,7 @@ Parsing an expression, we parsed "( <arg>" so far; an operator such as
 
 program: PRINT LPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 15.
+## Ends in an error in state: 21.
 ##
 ## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ NEWLINE IDENTIFIER ]
 ##
@@ -397,7 +397,7 @@ literal value) is now expected to construct an expression
 
 program: PRINT TRIPLE_DOT 
 ##
-## Ends in an error in state: 13.
+## Ends in an error in state: 19.
 ##
 ## instruction -> PRINT . expression [ NEWLINE ]
 ##
@@ -412,7 +412,7 @@ to construct a print instruction
 
 program: READ TRIPLE_DOT 
 ##
-## Ends in an error in state: 11.
+## Ends in an error in state: 17.
 ##
 ## instruction -> READ . variable [ NEWLINE ]
 ##
@@ -428,12 +428,12 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 66.
+## Ends in an error in state: 68.
 ##
-## list(instruction_line) -> instruction_line . list(instruction_line) [ EOF ]
+## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
-## instruction_line 
+## scope_annotation instruction NEWLINE 
 ##
 
 We parsed a complete instruction line, and are now inspecting a valid
@@ -441,9 +441,9 @@ instruction on the next line, or the end of the file.
 
 program: STOP TRIPLE_DOT 
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 67.
 ##
-## instruction_line -> scope_annotation instruction . NEWLINE [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ STOP READ PRINT MUT LBRACE INVALIDATE IDENTIFIER GOTO EOF CONST COMMENT BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction 

--- a/parser.mly
+++ b/parser.mly
@@ -25,7 +25,7 @@ let scope_annotation (mode, xs) =
 %%
 
 program:
-| prog=list(instruction_line) EOF
+| optional_newlines prog=list(instruction_line) EOF
   {
     let annotations, instructions = List.split prog in
     (Array.of_list instructions,
@@ -33,11 +33,13 @@ program:
   }
 
 instruction_line:
-| a=scope_annotation i=instruction NEWLINE { (a, i) }
+| a=scope_annotation i=instruction NEWLINE optional_newlines { (a, i) }
 
 scope_annotation:
 | { None }
-| annot=delimited(LBRACE, scope, RBRACE) { Some (scope_annotation annot) }
+| annot=delimited(LBRACE, scope, RBRACE) optional_newlines { Some (scope_annotation annot) }
+
+optional_newlines: list(NEWLINE) { () }
 
 scope:
 | x=variable COMMA sc=scope { let (mode, xs) = sc in (mode, x::xs) }


### PR DESCRIPTION
While working on this PR I noticed that branch pruning currently generates labels of the form `%foo`, which are not accepted by the parser. I understand now why @mhyee tried to write all his labels in his syntax previously.

@o-, @mhyee, should we distinguish labels from identifiers by asking that all labels start with `%`? Or should we allow labels to start with `%`? Or should we change the code to not generate `%`?