### PR TITLE
More precise scoping and undefined variables

### DIFF
--- a/assembler.ml
+++ b/assembler.ml
@@ -71,7 +71,7 @@ module OO = struct
   end
 
   let const x e = Decl_const (x#variable, e#expression)
-  let mut x e = Decl_mut (x#variable, e#expression)
+  let mut x e = Decl_mut (x#variable, Some e#expression)
   let assign x e = Assign (x#variable, e#expression)
   let read x = Read (x#variable)
   let print e = Print (e#expression)

--- a/disasm.ml
+++ b/disasm.ml
@@ -23,7 +23,8 @@ let disassemble_annotated (prog : Scope.annotated_program) =
     end;
     begin match instr with
     | Decl_const (var, exp)           -> pr buf " const %s = " var; dump_expr exp
-    | Decl_mut (var, exp)             -> pr buf " mut %s = " var; dump_expr exp
+    | Decl_mut (var, Some exp)        -> pr buf " mut %s = " var; dump_expr exp
+    | Decl_mut (var, None)            -> pr buf " mut %s" var
     | Assign (var, exp)               -> pr buf " %s <- " var; dump_expr exp
     | Branch (exp, l1, l2)            -> pr buf " branch "; dump_expr exp; pr buf " %s %s" l1 l2
     | Label label                     -> pr buf "%s:" label

--- a/parse.ml
+++ b/parse.ml
@@ -15,7 +15,7 @@ let parse lexbuf =
   let input = Interp.lexer_lexbuf_to_supplier Lexer.token lexbuf in
   let success prog = prog in
   let failure error_state =
-    let env = match error_state with
+    let env = match[@warning "-4"] error_state with
       | Interp.HandlingError env -> env
       | _ -> assert false in
     match Interp.stack env with

--- a/parser.mly
+++ b/parser.mly
@@ -49,8 +49,10 @@ scope:
 instruction:
 | CONST x=variable EQUAL e=expression
   { Decl_const (x, e) }
+| MUT x=variable
+  { Decl_mut (x, None) }
 | MUT x=variable EQUAL e=expression
-  { Decl_mut (x, e) }
+  { Decl_mut (x, Some e) }
 | x=variable LEFTARROW e=expression
   { Assign (x, e) }
 | BRANCH e=expression l1=label l2=label

--- a/sourir.ml
+++ b/sourir.ml
@@ -14,10 +14,24 @@ let () =
         exit 2
     in
     begin match Scope.infer annotated_program with
-      | exception Scope.UndefinedVariable xs ->
+      | exception Scope.UndeclaredVariable xs ->
         begin match Instr.VarSet.elements xs with
-          | [x] -> Printf.eprintf "Error: Variable %s undefined.\n%!" x
-          | xs -> Printf.eprintf "Error: Variables {%s} undefined.\n%!"
+          | [x] -> Printf.eprintf "Error: Variable %s is not declared.\n%!" x
+          | xs -> Printf.eprintf "Error: Variables {%s} are not declared.\n%!"
+                    (String.concat ", " xs)
+        end;
+        exit 1
+      | exception Scope.UninitializedVariable xs ->
+        begin match Instr.VarSet.elements xs with
+          | [x] -> Printf.eprintf "Error: Variable %s might be uninitialized.\n%!" x
+          | xs -> Printf.eprintf "Error: Variables {%s} might be uninitialized.\n%!"
+                    (String.concat ", " xs)
+        end;
+        exit 1
+      | exception Scope.DuplicateVariable xs ->
+        begin match Instr.VarSet.elements xs with
+          | [x] -> Printf.eprintf "Error: Variable %s is declared more than once.\n%!" x
+          | xs -> Printf.eprintf "Error: Variables {%s} are declared more than once.\n%!"
                     (String.concat ", " xs)
         end;
         exit 1


### PR DESCRIPTION
This commit introduces undefined variables on the Heap. They can
be declared by "mut x" (ie. a mut declaration without the definition
part). Every heap cell is now | Value v | Undefined.

To deal with the increased possibility for errors the Scope.infer
now keeps track of initialization (ie. first definition) of variables
and raises an exception on use-before-define. The api of infer is
unchanged the additional information is only internal.

Additionally Scope.infer rejects shadowing (ie. declaration of a
previously declared variable).