### PR TITLE
cfg analysis

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,8 +1,36 @@
-let print_set ppf (set : Instr.VarSet.t) =
+let print_set_vars ppf (set : Instr.VarSet.t) =
   Instr.VarSet.elements set
    |> List.map (Printf.sprintf "%S")
    |> String.concat "; "
    |> Format.fprintf ppf "[%s]"
 ;;
 
-#install_printer print_set;;
+let print_set_vars2 ppf (set : Cfg.BasicBlockSet.t) =
+  let open Cfg in
+  List.map (fun (e : basic_block) -> e.id) (BasicBlockSet.elements set)
+   |> List.map (Printf.sprintf "%d")
+   |> String.concat ";"
+   |> Format.fprintf ppf "[%s]"
+;;
+
+let print_set_vars3 ppf (set : Analysis.InstrSet.t) =
+  let open Analysis in
+  Analysis.InstrSet.elements set
+   |> List.map (Printf.sprintf "%d")
+   |> String.concat ";"
+   |> Format.fprintf ppf "[%s]"
+;;
+
+let print_program ppf (program : Instr.program) =
+  Format.fprintf ppf "%s" (Disasm.disassemble program)
+;;
+
+let print_an_program ppf (program : Instr.annotated_program) =
+  Format.fprintf ppf "%s" (Disasm.disassemble_annotated program)
+;;
+
+#install_printer print_set_vars;;
+#install_printer print_set_vars2;;
+#install_printer print_set_vars3;;
+#install_printer print_program;;
+#install_printer print_an_program;;

--- a/analysis.ml
+++ b/analysis.ml
@@ -185,3 +185,4 @@ let used prog : pc -> InstrSet.t =
         let uses_of var = VariableMap.at var res in
         let all_uses = List.map uses_of defined in
         List.fold_left InstrSet.union InstrSet.empty all_uses
+

--- a/cfg.ml
+++ b/cfg.ml
@@ -1,0 +1,103 @@
+open Instr
+open Analysis
+
+type basic_block = { id : int; entry : pc; exit : pc; mutable succ : basic_block list }
+module BasicBlock = struct
+  type t = basic_block
+  let compare a b = Pervasives.compare a.id b.id
+end
+
+type cfg = basic_block array
+
+module Cfg = struct
+  let node_at cfg pc =
+    let rec node_at id =
+      assert (id < Array.length cfg);
+      let node = cfg.(id) in
+      if node.entry <= pc && node.exit >= pc then node
+      else node_at (id+1) in
+    node_at 0
+
+  let of_program program : cfg =
+    let rec next_exit pc =
+      if Array.length program = pc then (pc-1)
+      else
+        match[@warning "-4"] program.(pc) with
+        | Goto _ | Branch _ | Stop -> pc
+        (* Fall through to another label exits the basic block *)
+        | Label _ -> (pc-1)
+        | _ -> next_exit (pc+1)
+    in
+    let rec find_nodes work id acc : basic_block list =
+      match work with
+      | [] -> acc
+      | pc :: rest ->
+          let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
+          if seen acc pc then find_nodes rest id acc
+          else
+            (* first bb starts without label *)
+            let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
+            let node = {id = id; entry = pc; exit = exit; succ = []} in
+            let acc = node :: acc in
+            let succ = successors program exit in
+            let succ = List.filter (fun pc -> not (seen acc pc)) succ in
+            (* explore cfg depth first to ensure topological order of id *)
+            find_nodes (succ @ rest) (id+1) acc
+    in
+    let entries = find_nodes [0] 0 [] in
+    let cfg = Array.of_list (List.rev entries) in
+    (* TODO: maybe assign the successors in the above loop
+     * but its kinda hard with the order constraints *)
+    let update_succ node =
+      let succ = successors program node.exit in
+      let succ = List.map (fun pc -> node_at cfg pc) succ in
+      node.succ <- succ;
+    in
+    Array.iter update_succ cfg;
+    cfg
+end
+
+module BasicBlockSet = Set.Make(BasicBlock)
+
+let cfg_dataflow_analysis (init_state : 'a)
+                          (cfg : cfg)
+                          (merge : 'a -> 'a -> 'a option)
+                          (update : basic_block -> 'a -> 'a)
+                          : 'a array =
+  let program_state = Array.make (Array.length cfg) None in
+  let rec work = function
+    | [] -> ()
+    | (in_state, bb) :: rest ->
+        let merged =
+          match program_state.(bb.id) with
+          | None -> Some in_state
+          | Some cur_state -> merge cur_state in_state
+        in begin match merged with
+        | None -> work rest
+        | Some merged ->
+            program_state.(bb.id) <- Some merged;
+            let updated = update bb merged in
+            let new_work = List.map (fun bb -> (updated, bb)) bb.succ in
+            work (new_work @ rest)
+        end
+  in
+  work [(init_state, cfg.(0))];
+  Array.map (fun state ->
+    match state with
+    | None -> assert(false)
+    | Some x -> x) program_state
+
+let dominators (program, cfg) =
+  let merge cur_dom in_dom =
+    let merged = BasicBlockSet.inter cur_dom in_dom in
+    if BasicBlockSet.equal cur_dom merged then None else Some merged
+  in
+  let update node dom = BasicBlockSet.add node dom in
+  cfg_dataflow_analysis BasicBlockSet.empty cfg merge update
+
+let common_dominator (program, cfg, doms) pcs =
+  let nodes = List.map (Cfg.node_at cfg) pcs in
+  let doms = List.map (fun n -> BasicBlockSet.add n doms.(n.id)) nodes in
+  let common = List.fold_left BasicBlockSet.inter (List.hd doms) (List.tl doms) in
+  assert (not (BasicBlockSet.is_empty common));
+  BasicBlockSet.max_elt common

--- a/cfg.ml
+++ b/cfg.ml
@@ -1,7 +1,4 @@
-open Instr
-open Analysis
-
-type basic_block = { id : int; entry : pc; exit : pc; mutable succ : basic_block list }
+type basic_block = { id : int; entry : Instr.pc; exit : Instr.pc; mutable succ : basic_block list }
 module BasicBlock = struct
   type t = basic_block
   let compare a b = Pervasives.compare a.id b.id
@@ -9,53 +6,52 @@ end
 
 type cfg = basic_block array
 
-module Cfg = struct
-  let node_at cfg pc =
-    let rec node_at id =
-      assert (id < Array.length cfg);
-      let node = cfg.(id) in
-      if node.entry <= pc && node.exit >= pc then node
-      else node_at (id+1) in
-    node_at 0
+let node_at cfg pc =
+  let rec node_at id =
+    assert (id < Array.length cfg);
+    let node = cfg.(id) in
+    if node.entry <= pc && node.exit >= pc then node
+    else node_at (id+1) in
+  node_at 0
 
-  let of_program program : cfg =
-    let rec next_exit pc =
-      if Array.length program = pc then (pc-1)
-      else
-        match[@warning "-4"] program.(pc) with
-        | Goto _ | Branch _ | Stop -> pc
-        (* Fall through to another label exits the basic block *)
-        | Label _ -> (pc-1)
-        | _ -> next_exit (pc+1)
-    in
-    let rec find_nodes work id acc : basic_block list =
-      match work with
-      | [] -> acc
-      | pc :: rest ->
-          let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
-          if seen acc pc then find_nodes rest id acc
-          else
-            (* first bb starts without label *)
-            let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
-            let node = {id = id; entry = pc; exit = exit; succ = []} in
-            let acc = node :: acc in
-            let succ = successors program exit in
-            let succ = List.filter (fun pc -> not (seen acc pc)) succ in
-            (* explore cfg depth first to ensure topological order of id *)
-            find_nodes (succ @ rest) (id+1) acc
-    in
-    let entries = find_nodes [0] 0 [] in
-    let cfg = Array.of_list (List.rev entries) in
-    (* TODO: maybe assign the successors in the above loop
-     * but its kinda hard with the order constraints *)
-    let update_succ node =
-      let succ = successors program node.exit in
-      let succ = List.map (fun pc -> node_at cfg pc) succ in
-      node.succ <- succ;
-    in
-    Array.iter update_succ cfg;
-    cfg
-end
+let of_program program : cfg =
+  let rec next_exit pc =
+    let open Instr in
+    if Array.length program = pc then (pc-1)
+    else
+      match[@warning "-4"] program.(pc) with
+      | Goto _ | Branch _ | Stop -> pc
+      (* Fall through to another label exits the basic block *)
+      | Label _ -> (pc-1)
+      | _ -> next_exit (pc+1)
+  in
+  let rec find_nodes work id acc : basic_block list =
+    match work with
+    | [] -> acc
+    | pc :: rest ->
+        let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
+        if seen acc pc then find_nodes rest id acc
+        else
+          (* first bb starts without label *)
+          let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
+          let node = {id = id; entry = pc; exit = exit; succ = []} in
+          let acc = node :: acc in
+          let succ = Analysis.successors program exit in
+          let succ = List.filter (fun pc -> not (seen acc pc)) succ in
+          (* explore cfg depth first to ensure topological order of id *)
+          find_nodes (succ @ rest) (id+1) acc
+  in
+  let entries = find_nodes [0] 0 [] in
+  let cfg = Array.of_list (List.rev entries) in
+  (* TODO: maybe assign the successors in the above loop
+   * but its kinda hard with the order constraints *)
+  let update_succ node =
+    let succ = Analysis.successors program node.exit in
+    let succ = List.map (fun pc -> node_at cfg pc) succ in
+    node.succ <- succ;
+  in
+  Array.iter update_succ cfg;
+  cfg
 
 module BasicBlockSet = Set.Make(BasicBlock)
 
@@ -96,7 +92,7 @@ let dominators (program, cfg) =
   cfg_dataflow_analysis BasicBlockSet.empty cfg merge update
 
 let common_dominator (program, cfg, doms) pcs =
-  let nodes = List.map (Cfg.node_at cfg) pcs in
+  let nodes = List.map (node_at cfg) pcs in
   let doms = List.map (fun n -> BasicBlockSet.add n doms.(n.id)) nodes in
   let common = List.fold_left BasicBlockSet.inter (List.hd doms) (List.tl doms) in
   assert (not (BasicBlockSet.is_empty common));

--- a/sourir.mllib
+++ b/sourir.mllib
@@ -8,3 +8,4 @@ Eval
 Disasm
 Analysis
 Transform
+Cfg

--- a/tests.ml
+++ b/tests.ml
@@ -484,11 +484,11 @@ end:
 ")
 
 let do_test_dom prog = function () ->
-  let open Cfg in
   let cfg = Cfg.of_program prog in
-  let doms = dominators (prog, cfg) in
-  let c = common_dominator (test_df2, cfg, doms) [12; 19] in
+  let doms = Cfg.dominators (prog, cfg) in
+  let c = Cfg.common_dominator (test_df2, cfg, doms) [12; 19] in
   let expected = Cfg.node_at cfg 9 in
+  let open Cfg in
   assert_equal c.id expected.id
 
 let suite =

--- a/tests.ml
+++ b/tests.ml
@@ -356,6 +356,49 @@ l2:
 l3:
 ")
 
+let do_test_dom1 = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program test_df in
+  let doms = dominators (test_df, cfg) in
+  let expected = [| []; [0]; [0;1]; [0;1;2]; |] in
+  let got = Array.map (fun s ->
+    List.map (fun n -> n.id) (BasicBlockSet.elements s)) doms in
+  assert_equal got expected;
+  let c1 = common_dominator (test_df, cfg, doms) [8; 14] in
+  let c2 = common_dominator (test_df, cfg, doms) [8; 13] in
+  let c3 = common_dominator (test_df, cfg, doms) [12; 13] in
+  assert_equal c1.id 1;
+  assert_equal c2.id 1;
+  assert_equal c3.id 2
+
+(* compare a CFG against a blueprint. The blueprint uses
+ * array indices as successors instead of references to the
+ * successor BB.
+ * This is required since otherwise it is (i) annoying to
+ * construct the expected CFG and (ii) assert_equals diverges
+ * on circular CFGs *)
+type bb_blueprint = {entry : pc; exit : pc; succ : int list}
+let compare_cfg (cfg : Cfg.cfg) (cfg_blueprint : bb_blueprint array) =
+  let open Cfg in
+  assert_equal (Array.length cfg) (Array.length cfg_blueprint);
+  Array.iteri (fun i (expected : bb_blueprint) ->
+      let node = cfg.(i) in
+      assert_equal expected.entry node.entry;
+      assert_equal expected.exit node.exit;
+      let succ = List.map (fun n -> n.id) node.succ in
+      assert_equal expected.succ succ
+    ) cfg_blueprint
+
+let do_test_cfg = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program test_df in
+  let expected = [|
+      {entry=0; exit=5; succ=[1]};
+      {entry=6; exit=9; succ=[1;2]};
+      {entry=11; exit=13; succ=[1;3]};
+      {entry=14; exit=14; succ=[]} |] in
+  compare_cfg cfg expected
+
 let do_test_liveness = function () ->
   let open Analysis in
   let live = live test_df in
@@ -402,6 +445,51 @@ let do_test_reaching = function () ->
   assert_equal_sorted (InstrSet.elements (reaching 7)) [8;0;4];
   assert_equal_sorted (InstrSet.elements (reaching 12)) [8;7];
   assert_equal_sorted (InstrSet.elements (reaching 0)) []
+
+let test_df2 = fst (Parse.parse_string
+" goto jmp
+start:
+  mut i = 1
+  mut c = 0
+  mut v = 123
+  mut x = 0
+  loop:
+    branch (i==10) loop_end loop_begin
+  loop_begin:
+    mut w = 3
+    branch (c==2) tr fs
+    tr:
+      w <- 3
+      goto ct
+    fs:
+      branch (c==4) tr2 fs2
+      tr2:
+        stop
+    fs2:
+      w <- 4
+      goto ct
+  ct:
+    x <- w
+    v <- (c+1)
+    i <- (i+v)
+    goto loop
+loop_end:
+  print i
+  print x
+  # bla
+  goto end
+jmp:
+  branch true start end
+end:
+")
+
+let do_test_dom prog = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program prog in
+  let doms = dominators (prog, cfg) in
+  let c = common_dominator (test_df2, cfg, doms) [12; 19] in
+  let expected = Cfg.node_at cfg 9 in
+  assert_equal c.id expected.id
 
 let suite =
   let open Assembler in
@@ -475,6 +563,9 @@ let suite =
    "reaching">:: do_test_reaching;
    "used">:: do_test_used;
    "liveness">:: do_test_liveness;
+   "cfg">:: do_test_cfg;
+   "dom">:: do_test_dom1;
+   "dom2">:: do_test_dom test_df2;
    ]
 ;;
 


### PR DESCRIPTION
CFG analysis

Basic blocks have a list of the successor BBs. We could also look at the exit instruction to determine the successors on the fly. For efficiency and convenience I decided to precompute it.

Basic block ids are increasing on fwd edges for cheap least dominator discovery.