### PR TITLE
Codemotion and fixes

### DIFF
--- a/.ocamlinit
+++ b/.ocamlinit
@@ -25,8 +25,8 @@ let print_program ppf (program : Instr.program) =
   Format.fprintf ppf "%s" (Disasm.disassemble program)
 ;;
 
-let print_an_program ppf (program : Instr.annotated_program) =
-  Format.fprintf ppf "%s" (Disasm.disassemble_annotated program)
+let print_an_program ppf (program : Instr.program) =
+  Format.fprintf ppf "%s" (Disasm.disassemble program)
 ;;
 
 #install_printer print_set_vars;;

--- a/.ocamlinit
+++ b/.ocamlinit
@@ -1,8 +1,36 @@
-let print_set ppf (set : Instr.VarSet.t) =
+let print_set_vars ppf (set : Instr.VarSet.t) =
   Instr.VarSet.elements set
    |> List.map (Printf.sprintf "%S")
    |> String.concat "; "
    |> Format.fprintf ppf "[%s]"
 ;;
 
-#install_printer print_set;;
+let print_set_vars2 ppf (set : Cfg.BasicBlockSet.t) =
+  let open Cfg in
+  List.map (fun (e : basic_block) -> e.id) (BasicBlockSet.elements set)
+   |> List.map (Printf.sprintf "%d")
+   |> String.concat ";"
+   |> Format.fprintf ppf "[%s]"
+;;
+
+let print_set_vars3 ppf (set : Analysis.InstrSet.t) =
+  let open Analysis in
+  Analysis.InstrSet.elements set
+   |> List.map (Printf.sprintf "%d")
+   |> String.concat ";"
+   |> Format.fprintf ppf "[%s]"
+;;
+
+let print_program ppf (program : Instr.program) =
+  Format.fprintf ppf "%s" (Disasm.disassemble program)
+;;
+
+let print_an_program ppf (program : Instr.annotated_program) =
+  Format.fprintf ppf "%s" (Disasm.disassemble_annotated program)
+;;
+
+#install_printer print_set_vars;;
+#install_printer print_set_vars2;;
+#install_printer print_set_vars3;;
+#install_printer print_program;;
+#install_printer print_an_program;;

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ run: sourir
 
 test_examples: sourir
 	for f in examples/*.sou; do yes 0 | ./sourir $$f > /dev/null; done
+	for f in examples/*.sou; do yes 0 | ./sourir --prune $$f > /dev/null; done
+	for f in examples/*.sou; do yes 0 | ./sourir --cm $$f > /dev/null; done
 	for f in examples/*.sou; do yes 0 | ./sourir --cm --prune $$f > /dev/null; done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ run: sourir
 
 test_examples: sourir
 	for f in examples/*.sou; do yes 0 | ./sourir $$f > /dev/null; done
+	for f in examples/*.sou; do yes 0 | ./sourir --cm --prune $$f > /dev/null; done
 
 clean:
 	ocamlbuild -clean

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,19 @@ runtop: lib
 run: sourir
 	./sourir examples/sum.sou
 
+TEMPDIR := $(shell mktemp -d)
+
 test_examples: sourir
-	for f in examples/*.sou; do yes 0 | ./sourir $$f > /dev/null; done
-	for f in examples/*.sou; do yes 0 | ./sourir --prune $$f > /dev/null; done
-	for f in examples/*.sou; do yes 0 | ./sourir --cm $$f > /dev/null; done
-	for f in examples/*.sou; do yes 0 | ./sourir --cm --prune $$f > /dev/null; done
+	mkdir $(TEMPDIR)/examples
+	for f in examples/*.sou; do yes 0 | ./sourir --quiet $$f              > $(TEMPDIR)/$$f.out; done
+	for f in examples/*.sou; do yes 0 | ./sourir --quiet --prune $$f      > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 0 | ./sourir --quiet --cm $$f         > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 0 | ./sourir --quiet --cm --prune $$f > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir --quiet $$f              > $(TEMPDIR)/$$f.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir --quiet --prune $$f      > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir --quiet --cm $$f         > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir --quiet --cm --prune $$f > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	rm -rf $(TEMPDIR)
 
 clean:
 	ocamlbuild -clean

--- a/analysis.ml
+++ b/analysis.ml
@@ -185,3 +185,4 @@ let used prog : pc -> InstrSet.t =
         let uses_of var = VariableMap.at var res in
         let all_uses = List.map uses_of defined in
         List.fold_left InstrSet.union InstrSet.empty all_uses
+

--- a/analysis.ml
+++ b/analysis.ml
@@ -144,7 +144,7 @@ let reaching prog : pc -> InstrSet.t =
   let update pc defs =
     let instr = prog.(pc) in
     (* add or override defined vars in one go*)
-    let kill = VarSet.elements (defined_vars instr) in
+    let kill = TypedVarSet.vars (defined_vars instr) in
     let loc = InstrSet.singleton pc in
     let replace acc var = VariableMap.add var loc acc in
     List.fold_left replace defs kill
@@ -169,7 +169,7 @@ let liveness_analysis prog =
   let update pc uses =
     let instr = prog.(pc) in
     (* First remove defined vars *)
-    let kill = VarSet.elements (defined_vars instr) in
+    let kill = TypedVarSet.vars (defined_vars instr) in
     let remove acc var = VariableMap.remove var acc in
     let uses = List.fold_left remove uses kill in
     (* Then add used vars *)
@@ -200,7 +200,7 @@ let used prog : pc -> InstrSet.t =
     match res.(pc) with
     | None -> raise (DeadCode pc)
     | Some res ->
-        let defined = VarSet.elements (defined_vars instr) in
+        let defined = TypedVarSet.vars (defined_vars instr) in
         let uses_of var = VariableMap.at var res in
         let all_uses = List.map uses_of defined in
         List.fold_left InstrSet.union InstrSet.empty all_uses

--- a/analysis.ml
+++ b/analysis.ml
@@ -1,38 +1,43 @@
 open Instr
 
-let successors program pc =
+let successors (code : instruction_stream) pc =
   let pc' = pc + 1 in
-  let next = if pc' = Array.length program then [] else [pc'] in
-  let resolve = Instr.resolve program in
-  match program.(pc) with
+  let next = if pc' = Array.length code then [] else [pc'] in
+  let resolve = Instr.resolve code in
+  match code.(pc) with
   | Decl_const _
   | Decl_mut _
   | Assign _
   | Label _
   | Comment _
   | Read _
+  (* Optimizations are applied within one context, therefore our analysis does
+   * not follow invalidate label by default.
+   * For a counterexample see Scope.infer_whole_program *)
+  | Invalidate _
+  | EndOpt
   | Print _ -> next
   | Goto l -> [resolve l]
-  | Invalidate (_, l, _) -> next @ [resolve l]
   | Branch (_e, l1, l2) -> [resolve l1; resolve l2]
   | Stop -> []
 
-let predecessors program =
-  let preds = Array.map (fun _ -> []) program in
+let predecessors (code : instruction_stream) =
+  let preds = Array.map (fun _ -> []) code in
   let mark_successor pc pc' =
     preds.(pc') <- pc :: preds.(pc') in
-  for pc = 0 to Array.length program - 1 do
-    List.iter (mark_successor pc) (successors program pc)
+  for pc = 0 to Array.length code - 1 do
+    List.iter (mark_successor pc) (successors code pc)
   done;
   preds
 
-let dataflow_analysis (next : pc -> pc list)
-                      (init_state : ('a * pc) list)
-                      (program : program)
+type succ_fun = pc -> pc list
+
+let dataflow_analysis (init_state : ('a * pc) list)
+                      (code : instruction_stream)
                       (merge : 'a -> 'a -> 'a option)
-                      (update : pc -> 'a -> 'a)
+                      (update : pc -> 'a -> ('a * pc) list)
                       : 'a option array =
-  let program_state = Array.map (fun _ -> None) program in
+  let program_state = Array.map (fun _ -> None) code in
   let rec work = function
     | [] -> ()
     | (in_state, pc) :: rest ->
@@ -44,14 +49,27 @@ let dataflow_analysis (next : pc -> pc list)
         | None -> work rest
         | Some new_state ->
             program_state.(pc) <- merged;
-            let updated = update pc new_state in
-            let cont = next pc in
-            let new_work = List.map (fun pc -> (updated, pc)) cont in
+            let new_work = update pc new_state in
             work (new_work @ rest)
         end
   in
   work init_state;
   program_state
+
+(* Symmetric means that if an instruction has multiple successors
+ * both of them get the same in_set *)
+let symmetric_dataflow_analysis (next : pc -> pc list)
+                                (init_state : ('a * pc) list)
+                                (code : instruction_stream)
+                                (merge : 'a -> 'a -> 'a option)
+                                (update : pc -> 'a -> 'a)
+                                : 'a option array =
+  let symmetric_update pc new_state =
+    let updated = update pc new_state in
+    let cont = next pc in
+    List.map (fun pc -> (updated, pc)) cont
+  in
+  dataflow_analysis init_state code merge symmetric_update
 
 let exits program =
   let rec exits pc : Pc.t list =
@@ -62,12 +80,12 @@ let exits program =
   in
   exits 0
 
-let forward_analysis_from init_pos init_state program =
+let symmetric_forward_analysis_from init_pos init_state program =
   let successors pc = successors program pc in
-  dataflow_analysis successors [(init_state, init_pos)] program
+  symmetric_dataflow_analysis successors [(init_state, init_pos)] program
 
-let forward_analysis init_state program =
-  forward_analysis_from 0 init_state program
+let symmetric_forward_analysis init_state program =
+  symmetric_forward_analysis_from 0 init_state program
 
 let backwards_analysis init_state program =
   let exits = exits program in
@@ -75,7 +93,7 @@ let backwards_analysis init_state program =
   let init_state = List.map (fun pc -> (init_state, pc)) exits in
   let preds = predecessors program in
   let predecessors pc = preds.(pc) in
-  dataflow_analysis predecessors init_state program
+  symmetric_dataflow_analysis predecessors init_state program
 
 
 
@@ -131,7 +149,7 @@ let reaching prog : pc -> InstrSet.t =
     let replace acc var = VariableMap.add var loc acc in
     List.fold_left replace defs kill
   in
-  let res = forward_analysis VariableMap.empty prog merge update in
+  let res = symmetric_forward_analysis VariableMap.empty prog merge update in
   fun pc ->
     let instr = prog.(pc) in
     match res.(pc) with

--- a/analysis.ml
+++ b/analysis.ml
@@ -71,6 +71,7 @@ let forward_analysis init_state program =
 
 let backwards_analysis init_state program =
   let exits = exits program in
+  assert (exits <> []);
   let init_state = List.map (fun pc -> (init_state, pc)) exits in
   let preds = predecessors program in
   let predecessors pc = preds.(pc) in

--- a/cfg.ml
+++ b/cfg.ml
@@ -1,0 +1,103 @@
+open Instr
+open Analysis
+
+type basic_block = { id : int; entry : pc; exit : pc; mutable succ : basic_block list }
+module BasicBlock = struct
+  type t = basic_block
+  let compare a b = Pervasives.compare a.id b.id
+end
+
+type cfg = basic_block array
+
+module Cfg = struct
+  let node_at cfg pc =
+    let rec node_at id =
+      assert (id < Array.length cfg);
+      let node = cfg.(id) in
+      if node.entry <= pc && node.exit >= pc then node
+      else node_at (id+1) in
+    node_at 0
+
+  let of_program program : cfg =
+    let rec next_exit pc =
+      if Array.length program = pc then (pc-1)
+      else
+        match[@warning "-4"] program.(pc) with
+        | Goto _ | Branch _ | Stop -> pc
+        (* Fall through to another label exits the basic block *)
+        | Label _ -> (pc-1)
+        | _ -> next_exit (pc+1)
+    in
+    let rec find_nodes work id acc : basic_block list =
+      match work with
+      | [] -> acc
+      | pc :: rest ->
+          let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
+          if seen acc pc then find_nodes rest id acc
+          else
+            (* first bb starts without label *)
+            let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
+            let node = {id = id; entry = pc; exit = exit; succ = []} in
+            let acc = node :: acc in
+            let succ = successors program exit in
+            let succ = List.filter (fun pc -> not (seen acc pc)) succ in
+            (* explore cfg depth first to ensure topological order of id *)
+            find_nodes (succ @ rest) (id+1) acc
+    in
+    let entries = find_nodes [0] 0 [] in
+    let cfg = Array.of_list (List.rev entries) in
+    (* TODO: maybe assign the successors in the above loop
+     * but its kinda hard with the order constraints *)
+    let update_succ node =
+      let succ = successors program node.exit in
+      let succ = List.map (fun pc -> node_at cfg pc) succ in
+      node.succ <- succ;
+    in
+    Array.iter update_succ cfg;
+    cfg
+end
+
+module BasicBlockSet = Set.Make(BasicBlock)
+
+let cfg_dataflow_analysis (init_state : 'a)
+                          (cfg : cfg)
+                          (merge : 'a -> 'a -> 'a option)
+                          (update : basic_block -> 'a -> 'a)
+                          : 'a array =
+  let program_state = Array.make (Array.length cfg) None in
+  let rec work = function
+    | [] -> ()
+    | (in_state, bb) :: rest ->
+        let merged =
+          match program_state.(bb.id) with
+          | None -> Some in_state
+          | Some cur_state -> merge cur_state in_state
+        in begin match merged with
+        | None -> work rest
+        | Some merged ->
+            program_state.(bb.id) <- Some merged;
+            let updated = update bb merged in
+            let new_work = List.map (fun bb -> (updated, bb)) bb.succ in
+            work (new_work @ rest)
+        end
+  in
+  work [(init_state, cfg.(0))];
+  Array.map (fun state ->
+    match state with
+    | None -> assert(false)
+    | Some x -> x) program_state
+
+let dominators (program, cfg) =
+  let merge cur_dom in_dom =
+    let merged = BasicBlockSet.inter cur_dom in_dom in
+    if BasicBlockSet.equal cur_dom merged then None else Some merged
+  in
+  let update node dom = BasicBlockSet.add node dom in
+  cfg_dataflow_analysis BasicBlockSet.empty cfg merge update
+
+let common_dominator (program, cfg, doms) pcs =
+  let nodes = List.map (Cfg.node_at cfg) pcs in
+  let doms = List.map (fun n -> BasicBlockSet.add n doms.(n.id)) nodes in
+  let common = List.fold_left BasicBlockSet.inter (List.hd doms) (List.tl doms) in
+  assert (not (BasicBlockSet.is_empty common));
+  BasicBlockSet.max_elt common

--- a/cfg.ml
+++ b/cfg.ml
@@ -1,7 +1,4 @@
-open Instr
-open Analysis
-
-type basic_block = { id : int; entry : pc; exit : pc; mutable succ : basic_block list }
+type basic_block = { id : int; entry : Instr.pc; exit : Instr.pc; mutable succ : basic_block list }
 module BasicBlock = struct
   type t = basic_block
   let compare a b = Pervasives.compare a.id b.id
@@ -9,53 +6,52 @@ end
 
 type cfg = basic_block array
 
-module Cfg = struct
-  let node_at cfg pc =
-    let rec node_at id =
-      assert (id < Array.length cfg);
-      let node = cfg.(id) in
-      if node.entry <= pc && node.exit >= pc then node
-      else node_at (id+1) in
-    node_at 0
+let node_at cfg pc =
+  let rec node_at id =
+    assert (id < Array.length cfg);
+    let node = cfg.(id) in
+    if node.entry <= pc && node.exit >= pc then node
+    else node_at (id+1) in
+  node_at 0
 
-  let of_program program : cfg =
-    let rec next_exit pc =
-      if Array.length program = pc then (pc-1)
-      else
-        match[@warning "-4"] program.(pc) with
-        | Goto _ | Branch _ | Stop -> pc
-        (* Fall through to another label exits the basic block *)
-        | Label _ -> (pc-1)
-        | _ -> next_exit (pc+1)
-    in
-    let rec find_nodes work id acc : basic_block list =
-      match work with
-      | [] -> acc
-      | pc :: rest ->
-          let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
-          if seen acc pc then find_nodes rest id acc
-          else
-            (* first bb starts without label *)
-            let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
-            let node = {id = id; entry = pc; exit = exit; succ = []} in
-            let acc = node :: acc in
-            let succ = successors program exit in
-            let succ = List.filter (fun pc -> not (seen acc pc)) succ in
-            (* explore cfg depth first to ensure topological order of id *)
-            find_nodes (succ @ rest) (id+1) acc
-    in
-    let entries = find_nodes [0] 0 [] in
-    let cfg = Array.of_list (List.rev entries) in
-    (* TODO: maybe assign the successors in the above loop
-     * but its kinda hard with the order constraints *)
-    let update_succ node =
-      let succ = successors program node.exit in
-      let succ = List.map (fun pc -> node_at cfg pc) succ in
-      node.succ <- succ;
-    in
-    Array.iter update_succ cfg;
-    cfg
-end
+let of_program program : cfg =
+  let rec next_exit pc =
+    let open Instr in
+    if Array.length program = pc then (pc-1)
+    else
+      match[@warning "-4"] program.(pc) with
+      | Goto _ | Branch _ | Stop -> pc
+      (* Fall through to another label exits the basic block *)
+      | Label _ -> (pc-1)
+      | _ -> next_exit (pc+1)
+  in
+  let rec find_nodes work id acc : basic_block list =
+    match work with
+    | [] -> acc
+    | pc :: rest ->
+        let seen acc pc = List.exists (fun n -> n.entry = pc) acc in
+        if seen acc pc then find_nodes rest id acc
+        else
+          (* first bb starts without label *)
+          let exit = if pc = 0 then next_exit 0 else next_exit (pc+1) in
+          let node = {id = id; entry = pc; exit = exit; succ = []} in
+          let acc = node :: acc in
+          let succ = Analysis.successors program exit in
+          let succ = List.filter (fun pc -> not (seen acc pc)) succ in
+          (* explore cfg depth first to ensure topological order of id *)
+          find_nodes (succ @ rest) (id+1) acc
+  in
+  let entries = find_nodes [0] 0 [] in
+  let cfg = Array.of_list (List.rev entries) in
+  (* TODO: maybe assign the successors in the above loop
+   * but its kinda hard with the order constraints *)
+  let update_succ node =
+    let succ = Analysis.successors program node.exit in
+    let succ = List.map (fun pc -> node_at cfg pc) succ in
+    node.succ <- succ;
+  in
+  Array.iter update_succ cfg;
+  cfg
 
 module BasicBlockSet = Set.Make(BasicBlock)
 
@@ -96,7 +92,7 @@ let dominators (program, cfg) =
   cfg_dataflow_analysis BasicBlockSet.empty cfg merge update
 
 let common_dominator (program, cfg, doms) pcs =
-  let nodes = List.map (Cfg.node_at cfg) pcs in
+  let nodes = List.map (node_at cfg) pcs in
   let doms = List.map (fun n -> BasicBlockSet.add n doms.(n.id)) nodes in
   let common = List.fold_left BasicBlockSet.inter (List.hd doms) (List.tl doms) in
   assert (not (BasicBlockSet.is_empty common));

--- a/cfg.ml
+++ b/cfg.ml
@@ -4,7 +4,7 @@ type basic_block = {
   entry : Instr.pc;                (* first instruction *)
   exit : Instr.pc;                 (* last instruction *)
   prepend : Instr.pc;              (* insert at this pc to prepend (ie. after the label) *)
-  append : Instr.pc;               (* insert at this pc to append (ie. after the jump *)
+  append : Instr.pc;               (* insert at this pc to append (ie. before the jump *)
   mutable succ : basic_block list  (* successors *) }
 
 module BasicBlock = struct
@@ -16,10 +16,11 @@ type cfg = basic_block array
 
 let bb_at cfg pc =
   let rec bb_at id =
-    assert (id < Array.length cfg);
-    let node = cfg.(id) in
-    if node.entry <= pc && node.exit >= pc then node
-    else bb_at (id+1) in
+    if id = Array.length cfg then raise (Analysis.DeadCode pc)
+    else
+      let node = cfg.(id) in
+      if node.entry <= pc && node.exit >= pc then node
+      else bb_at (id+1) in
   bb_at 0
 
 let of_program program : cfg =

--- a/codemotion.ml
+++ b/codemotion.ml
@@ -1,0 +1,101 @@
+let dominates_all_uses (program, cfg, doms, used) pc =
+  let open Cfg in
+  let uses = used pc in
+  if Analysis.InstrSet.is_empty uses then true
+  else
+    let sentinel = {id = -1; entry = -1; exit = -1; prepend = -1; append = -1; succ = [cfg.(0)]} in
+    let bb_at pc = bb_at cfg pc in
+    let bb_def = bb_at pc in
+    let doms_def = doms.(bb_def.id) in
+    let dom_def = if BasicBlockSet.is_empty doms_def then sentinel
+          else BasicBlockSet.max_elt doms_def in
+    let uses = Analysis.InstrSet.elements uses in
+    let bb_uses = List.map (fun pc -> bb_at pc) uses in
+    let doms_uses = List.map (fun bb -> doms.(bb.id)) bb_uses in
+    let dom_uses = List.map (fun doms ->
+        if BasicBlockSet.is_empty doms then sentinel
+            else BasicBlockSet.max_elt doms) doms_uses in
+    List.for_all2 (fun use dom ->
+        dom_def.id < dom.id ||
+        (* common dominator and in the same basic block -> fine if def is before use
+         * (eg. linear loop body with both def and use) *)
+        (dom_def.id = dom.id && bb_def.id = (bb_at use).id &&
+           use > pc)) uses dom_uses
+
+let can_move_analysis (program, scope, cfg, doms, reaching, used) pc
+  : Cfg.basic_block option =
+  let defs = Instr.defined_vars program.(pc) in
+  (* 1. Condition: I have a dominator *)
+  let open Cfg in
+  let bb = bb_at cfg pc in
+  let my_doms = doms.(bb.id) in
+  if BasicBlockSet.is_empty my_doms then None
+  else
+    (* 2. Condition: I dominates all uses *)
+    if not (dominates_all_uses (program, cfg, doms, used) pc) then None
+    else
+      (* 3. Condition: All reaching definitions dominate me *)
+      let reaching_def = Analysis.InstrSet.elements (reaching pc) in
+      let reaching = List.map (fun pc -> bb_at cfg pc) reaching_def in
+      let dominates_me other =
+        match BasicBlockSet.find other my_doms with
+        | exception Not_found -> false
+        | _ -> true
+      in
+      let reaching_dominates_me = List.map dominates_me reaching in
+      if not (List.fold_left (&&) true reaching_dominates_me) then None
+      else
+        (* 4. Condition: Do not move above reaching definitions *)
+        let max_reaching =
+          if reaching = [] then -1 else (BasicBlockSet.max_elt (BasicBlockSet.of_list reaching)).id in
+        let move_candidates = BasicBlockSet.filter (fun bb ->
+            bb.id >= max_reaching) my_doms in
+        (* 5. Condition: Do not move out of scope *)
+        let open Instr in
+        let candidates_in_scope = BasicBlockSet.filter (fun bb ->
+            match[@warning "-4"] scope.(bb.append) with
+            | Scope scope when not (VarSet.is_empty (VarSet.inter defs scope)) -> true
+            | _ -> false) move_candidates in
+        (* Done *)
+        if BasicBlockSet.is_empty candidates_in_scope then None
+        else Some (BasicBlockSet.min_elt candidates_in_scope)
+
+let can_move prog =
+  let scope = Scope.infer (Scope.no_annotations prog) in
+  let cfg = Cfg.of_program prog in
+  let doms = Cfg.dominators (prog, cfg) in
+  let reaching = Analysis.reaching prog in
+  let used = Analysis.used prog in
+  can_move_analysis (prog, scope, cfg, doms, reaching, used)
+
+let rec apply (prog : Instr.program) : Instr.program =
+  let apply_step (prog : Instr.program) =
+    let scope = Scope.infer (Scope.no_annotations prog) in
+    let cfg = Cfg.of_program prog in
+    let doms = Cfg.dominators (prog, cfg) in
+    let reaching = Analysis.reaching prog in
+    let used = Analysis.used prog in
+    let can_move = can_move_analysis (prog, scope, cfg, doms, reaching, used) in
+
+    let rec get_move_candidate pc =
+      if pc = Array.length prog then None
+      else match can_move pc with
+        | None -> get_move_candidate (pc + 1)
+        | Some bb -> Some (pc, bb)
+    in
+
+    match get_move_candidate 0 with
+    | None -> None
+    | Some (pc, bb) ->
+      let open Cfg in
+      Some (Array.concat [
+        Array.sub prog 0 (bb.append);
+        [| prog.(pc) |];
+        Array.sub prog (bb.append) (pc-bb.append);
+        Array.sub prog (pc+1) ((Array.length prog)-(pc+1))
+      ])
+  in
+
+  match apply_step prog with
+  | None -> prog
+  | Some prog -> apply prog

--- a/codemotion.ml
+++ b/codemotion.ml
@@ -24,45 +24,70 @@ let dominates_all_uses (program, cfg, doms, used) pc =
         (dom_def.id = dom.id && bb_def.id = (bb_at use).id &&
            use > pc)) uses dom_uses
 
+let fresh_variable program =
+  let rec collect_vars pc =
+    if pc = Array.length program then TypedVarSet.empty
+    else
+      let vars = Instr.defined_vars program.(pc) in
+      TypedVarSet.union vars (collect_vars (pc+1))
+  in
+  let used = TypedVarSet.untyped (collect_vars 0) in
+  fun var ->
+    let rec find_next i =
+      let new_var = var ^ "." ^ (string_of_int i) in
+      match VarSet.find new_var used with
+      | exception Not_found -> new_var
+      | _ -> find_next (i+1)
+    in
+    find_next 0
+
 let can_move_analysis (program, scope, cfg, doms, reaching, used) pc
   : Cfg.basic_block option =
-  let defs = Instr.defined_vars program.(pc) in
   (* 1. Condition: I have a dominator *)
   let open Cfg in
   match bb_at cfg pc with
   | exception Analysis.DeadCode _ -> None
   | bb ->
-    let my_doms = doms.(bb.id) in
-    if BasicBlockSet.is_empty my_doms then None
-    else
-      (* 2. Condition: I dominates all uses *)
-      if not (dominates_all_uses (program, cfg, doms, used) pc) then None
+    let instr = program.(pc) in
+    match instr with
+    | Branch _ | Label _ | Goto _ | Read _ | Print _ | Invalidate _
+    | Stop | Comment _ | EndOpt | Decl_mut _ -> None
+    | Decl_const _ | Assign _ ->
+      let my_doms = doms.(bb.id) in
+      if BasicBlockSet.is_empty my_doms then None
       else
-        (* 3. Condition: All reaching definitions dominate me *)
-        let reaching_def = Analysis.InstrSet.elements (reaching pc) in
-        let reaching = List.map (fun pc -> bb_at cfg pc) reaching_def in
-        let dominates_me other =
-          match BasicBlockSet.find other my_doms with
-          | exception Not_found -> false
-          | _ -> true
-        in
-        let reaching_dominates_me = List.map dominates_me reaching in
-        if not (List.fold_left (&&) true reaching_dominates_me) then None
+        (* 2. Condition: I dominates all uses *)
+        if not (dominates_all_uses (program, cfg, doms, used) pc) then None
         else
-          (* 4. Condition: Do not move above reaching definitions *)
-          let max_reaching =
-            if reaching = [] then -1 else (BasicBlockSet.max_elt (BasicBlockSet.of_list reaching)).id in
-          let move_candidates = BasicBlockSet.filter (fun bb ->
-              bb.id >= max_reaching) my_doms in
-          (* 5. Condition: Do not move out of scope *)
-          let open Instr in
-          let candidates_in_scope = BasicBlockSet.filter (fun bb ->
-              match[@warning "-4"] scope.(bb.append) with
-              | Scope scope when not (TypedVarSet.is_empty (TypedVarSet.inter defs scope)) -> true
-              | _ -> false) move_candidates in
-          (* Done *)
-          if BasicBlockSet.is_empty candidates_in_scope then None
-          else Some (BasicBlockSet.min_elt candidates_in_scope)
+          (* 3. Condition: All reaching definitions dominate me *)
+          let reaching_def = Analysis.InstrSet.elements (reaching pc) in
+          let reaching = List.map (fun pc -> bb_at cfg pc) reaching_def in
+          let dominates_me other =
+            match BasicBlockSet.find other my_doms with
+            | exception Not_found -> false
+            | _ -> true
+          in
+          let reaching_dominates_me = List.map dominates_me reaching in
+          if not (List.fold_left (&&) true reaching_dominates_me) then None
+          else
+            (* 4. Condition: Do not move above reaching definitions *)
+            let max_reaching =
+              if reaching = [] then -1 else (BasicBlockSet.max_elt (BasicBlockSet.of_list reaching)).id in
+            let move_candidates = BasicBlockSet.filter (fun bb ->
+                bb.id >= max_reaching) my_doms in
+            (* 5. Condition: Do not move out of scope *)
+            let open Instr in
+            let needed_vars = TypedVarSet.diff (defined_vars instr) (declared_vars instr) in
+            let candidates_in_scope = if TypedVarSet.is_empty needed_vars then move_candidates
+              else BasicBlockSet.filter (fun bb ->
+                  match[@warning "-4"] scope.(bb.append) with
+                  | Scope scope when TypedVarSet.equal needed_vars
+                                       (TypedVarSet.inter needed_vars scope) -> true
+                  | _ -> false) move_candidates
+            in
+            (* Done *)
+            if BasicBlockSet.is_empty candidates_in_scope then None
+            else Some (BasicBlockSet.min_elt candidates_in_scope)
 
 let can_move (prog : instruction_stream) : pc -> Cfg.basic_block option =
   let scope = Scope.infer (Scope.no_annotations prog) in
@@ -71,6 +96,47 @@ let can_move (prog : instruction_stream) : pc -> Cfg.basic_block option =
   let reaching = Analysis.reaching prog in
   let used = Analysis.used prog in
   can_move_analysis (prog, scope, cfg, doms, reaching, used)
+
+let replace_used_var instr old_var new_var =
+  let replace_var_simple_exp exp old_var new_var =
+    match exp with
+    | Var v when v = old_var -> Var new_var
+    | Var _
+    | Lit _ -> exp
+  in
+  let replace_var_exp exp old_var new_var =
+    match exp with
+    | Simple e -> Simple (replace_var_simple_exp e old_var new_var)
+    | Op (Plus, [a; b]) ->
+      Op (Plus, [replace_var_simple_exp a old_var new_var;
+                 replace_var_simple_exp b old_var new_var])
+    | Op (Neq, [a; b]) ->
+      Op (Neq, [replace_var_simple_exp a old_var new_var;
+                replace_var_simple_exp b old_var new_var])
+    | Op (Eq, [a; b]) ->
+      Op (Eq, [replace_var_simple_exp a old_var new_var;
+               replace_var_simple_exp b old_var new_var])
+    | Op ((Plus | Neq | Eq), _) -> assert false
+  in
+  match instr with
+  | Decl_const (x, e) -> Decl_const (x, replace_var_exp e old_var new_var)
+  | Decl_mut (x, Some e) -> Decl_mut (x, Some (replace_var_exp e old_var new_var))
+  | Branch (e, l1, l2) -> Branch (replace_var_exp e old_var new_var, l1, l2)
+  | Read x when x = old_var -> Read new_var
+  | Print e -> Print (replace_var_exp e old_var new_var)
+  | Invalidate (e, l, xs) ->
+    Invalidate (replace_var_exp e old_var new_var, l,
+                { captured = List.map (fun v -> if v = old_var then new_var else v) xs.captured;
+                  out = xs.out })
+  | Assign (x, e) when x = old_var -> Assign (new_var, replace_var_exp e old_var new_var)
+  | Assign (x, e) -> Assign (x, replace_var_exp e old_var new_var)
+  | Decl_mut _
+  | Label _
+  | Goto _
+  | Read _
+  | Comment _
+  | EndOpt
+  | Stop -> instr
 
 let rec apply (prog : program) : program =
   let apply_step (prog : program) : program option =
@@ -90,19 +156,60 @@ let rec apply (prog : program) : program =
         | Some bb -> Some (pc, bb)
     in
 
+    let apply_move code used to_insert old_var new_var remove insert =
+      let len = Array.length code in
+      Analysis.InstrSet.iter (fun pc ->
+          code.(pc) <- replace_used_var code.(pc) old_var new_var
+        ) used;
+      if remove < insert then
+        Array.concat [
+          Array.sub code 0 remove;
+          Array.sub code (remove+1) (insert-remove-1);
+          [| to_insert |];
+          Array.sub code insert (len-insert)
+        ]
+      else
+        Array.concat [
+          Array.sub code 0 insert;
+          [| to_insert |];
+          Array.sub code insert (remove-insert);
+          Array.sub code (remove+1) (len-remove-1)
+        ]
+    in
+
     match get_move_candidate 0 with
     | None -> None
     | Some (pc, bb) ->
       let open Cfg in
-      let res = (Array.concat [
-        Array.sub code 0 (bb.append);
-        [| code.(pc) |];
-        Array.sub code (bb.append) (pc-bb.append);
-        Array.sub code (pc+1) ((Array.length code)-(pc+1))
-      ]) in
+      let used = used pc in
+      let fresh_var = fresh_variable code in
+      let res =
+        match[@warning "-4"] code.(pc) with
+        | Decl_const (x, e) ->
+          let new_var = fresh_var x in
+          apply_move
+            code
+            used
+            (Decl_const (new_var, e))
+            x
+            new_var
+            pc
+            bb.append
+        | Assign (x, e) ->
+          let new_var = fresh_var x in
+          apply_move
+            code
+            used
+            (Decl_mut (new_var, Some e))
+            x
+            new_var
+            pc
+            bb.append
+        | _ -> assert false
+      in
       Some (Scope.no_annotations res)
   in
 
   match apply_step prog with
   | None -> prog
-  | Some prog -> apply prog
+  | Some prog -> prog

--- a/codemotion.ml
+++ b/codemotion.ml
@@ -58,7 +58,7 @@ let can_move_analysis (program, scope, cfg, doms, reaching, used) pc
           let open Instr in
           let candidates_in_scope = BasicBlockSet.filter (fun bb ->
               match[@warning "-4"] scope.(bb.append) with
-              | Scope scope when not (VarSet.is_empty (VarSet.inter defs scope)) -> true
+              | Scope scope when not (TypedVarSet.is_empty (TypedVarSet.inter defs scope)) -> true
               | _ -> false) move_candidates in
           (* Done *)
           if BasicBlockSet.is_empty candidates_in_scope then None

--- a/disasm.ml
+++ b/disasm.ml
@@ -1,6 +1,6 @@
 open Instr
 
-let disassemble_annotated (prog : annotated_program) =
+let disassemble (prog : program) =
   let dump_instr buf instr annot =
     let pr = Printf.bprintf in
     let simple buf = function
@@ -34,13 +34,14 @@ let disassemble_annotated (prog : annotated_program) =
     | Invalidate (exp, l, vars)       -> pr buf " invalidate "; dump_expr exp;
                                          pr buf " %s [%s]" l (String.concat ", " vars)
     | Stop                            -> pr buf " stop"
+    | EndOpt                          -> pr buf " end_opt"
     | Comment str                     -> pr buf " #%s" str
     end;
     pr buf "\n"
   in
   let b = Buffer.create 1024 in
-  Array.iter2 (dump_instr b) (fst prog) (snd prog);
+  Array.iter2 (dump_instr b) prog.instructions prog.annotations;
   Buffer.contents b
 
-let disassemble (prog : Instr.program) =
-  disassemble_annotated (prog, Array.map (fun _ -> None) prog)
+let disassemble_stream (stream : instruction_stream) =
+  disassemble (Scope.no_annotations stream)

--- a/disasm.ml
+++ b/disasm.ml
@@ -31,8 +31,12 @@ let disassemble (prog : program) =
     | Goto label                      -> pr buf " goto %s" label
     | Print exp                       -> pr buf " print "; dump_expr exp
     | Read var                        -> pr buf " read %s" var
+    | Invalidate (exp, l, vars)
+      when vars.captured = []         -> pr buf " invalidate "; dump_expr exp;
+                                         pr buf " %s []" l
     | Invalidate (exp, l, vars)       -> pr buf " invalidate "; dump_expr exp;
-                                         pr buf " %s [%s]" l (String.concat ", " vars)
+                                         pr buf " %s [%s = %s]" l (String.concat ", " vars.out)
+                                                                  (String.concat ", " vars.captured)
     | Stop                            -> pr buf " stop"
     | EndOpt                          -> pr buf " end_opt"
     | Comment str                     -> pr buf " #%s" str

--- a/eval.ml
+++ b/eval.ml
@@ -15,7 +15,7 @@ type configuration = {
   trace : trace;
   heap : heap;
   env : environment;
-  program : program;
+  program : instruction_stream;
   pc : pc;
   status : status;
   deopt : string option;
@@ -121,10 +121,11 @@ let instruction conf =
 
 let reduce conf =
   let eval conf e = eval conf.heap conf.env e in
-  let resolve label = Instr.resolve conf.program label in
+  let resolve label = resolve conf.program label in
   let pc' = conf.pc + 1 in
   assert (conf.status = Running);
   match instruction conf with
+  | EndOpt
   | Comment _ -> { conf with
                    pc = pc' }
   | Stop -> { conf with

--- a/eval.ml
+++ b/eval.ml
@@ -182,12 +182,12 @@ let reduce conf =
          pc = pc';
        }
      else begin
-       let add env x =
-         match Env.find x conf.env with
-         | exception Not_found -> raise (Unbound_variable x)
-         | v -> Env.add x v env
+       let add env (old_name, new_name) =
+         match Env.find old_name conf.env with
+         | exception Not_found -> raise (Unbound_variable old_name)
+         | v -> Env.add new_name v env
        in
-       let new_env = List.fold_left add Env.empty xs in
+       let new_env = List.fold_left add Env.empty (List.combine xs.captured xs.out) in
        { conf with
          pc = resolve l;
          env = new_env;

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -10,7 +10,7 @@
   mut x = 30
   mut z = 0
   read z
-  invalidate (z == zero) l2 [zero, one, two, w1, w2, x, z]
+  invalidate (z == zero) l2 [zero, one, two, w1, w2, x, z = zero, one, two, w1, w2, x, z]
   x <- (x + one)
   print w1
   print w2

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -18,6 +18,7 @@
   print w2
   print x
   stop
+  end_opt
 l2:
   x <- (x + two)
   print w1

--- a/examples/scope_problems.sou
+++ b/examples/scope_problems.sou
@@ -1,0 +1,7 @@
+loop:
+ const d = 1
+ branch (d==1) cont loop2
+loop2:
+ print d
+ goto loop
+cont:

--- a/examples/scope_problems2.sou
+++ b/examples/scope_problems2.sou
@@ -1,0 +1,7 @@
+loop:
+ mut d = 1
+ branch (d==1) cont loop2
+loop2:
+ d <- 2
+ goto loop
+cont:

--- a/examples/scope_problems2.sou
+++ b/examples/scope_problems2.sou
@@ -3,5 +3,6 @@ loop:
  branch (d==1) cont loop2
 loop2:
  d <- 2
+ print d
  goto loop
 cont:

--- a/instr.ml
+++ b/instr.ml
@@ -29,6 +29,8 @@ end
 
 type pc = Pc.t
 
+type osr_def = { captured : variable list; out : variable list }
+
 type instruction_stream = instruction array
 and instruction =
   | Decl_const of variable * expression
@@ -39,7 +41,7 @@ and instruction =
   | Goto of label
   | Read of variable
   | Print of expression
-  | Invalidate of expression * label * variable list
+  | Invalidate of expression * label * osr_def
   | Stop
   | Comment of string
   | EndOpt
@@ -183,7 +185,7 @@ let required_vars = function
   | Read x -> VarSet.singleton x
   | Print e -> expr_vars e
   | Invalidate (e, _l, xs) ->
-    VarSet.union (VarSet.of_list xs) (expr_vars e)
+    VarSet.union (VarSet.of_list xs.captured) (expr_vars e)
   | EndOpt
   | Stop -> VarSet.empty
 
@@ -216,7 +218,7 @@ let used_vars = function
   | Read _ -> VarSet.empty
   | Print e -> expr_vars e
   | Invalidate (e, _l, xs) ->
-    VarSet.union (VarSet.of_list xs) (expr_vars e)
+    VarSet.union (VarSet.of_list xs.captured) (expr_vars e)
   | EndOpt
   | Stop -> VarSet.empty
 

--- a/instr.ml
+++ b/instr.ml
@@ -91,6 +91,61 @@ exception Unbound_label of label
 
 module VarSet = Set.Make(Variable)
 
+type typed_var =
+  | Mut_var of string
+  | Const_var of string
+
+exception Incomparable
+
+module TypedVar = struct
+  type t = typed_var
+  let compare a b =
+    match (a,b) with
+    | Mut_var   a, Mut_var   b
+    | Const_var a, Const_var b -> String.compare a b
+    | Mut_var   a, Const_var b
+    | Const_var a, Mut_var   b ->
+      if a = b then raise Incomparable else String.compare a b
+end
+
+module TypedVarSet = struct
+  include Set.Make(TypedVar)
+
+  let vars set =
+    List.map (fun v ->
+        match v with
+        | Mut_var x | Const_var x -> x)
+      (elements set)
+
+  let untyped set = VarSet.of_list (vars set)
+
+  let muts set =
+    let muts = filter (fun v ->
+        match v with
+        | Mut_var x -> true
+        | Const_var x -> false)
+      set in
+    untyped muts
+
+  let diff_untyped typed untyped =
+    filter (fun e ->
+        match e with
+        | Mut_var x | Const_var x ->
+          begin match VarSet.find x untyped with
+            | exception Not_found -> true
+            | _ -> false
+          end) typed
+
+  let inter_untyped typed untyped =
+    filter (fun e ->
+        match e with
+        | Mut_var x | Const_var x ->
+          begin match VarSet.find x untyped with
+            | exception Not_found -> false
+            | _ -> true
+          end) typed
+end
+
 let simple_expr_vars = function
   | Var x -> VarSet.singleton x
   | Lit _ -> VarSet.empty
@@ -102,8 +157,8 @@ let expr_vars = function
     |> List.fold_left VarSet.union VarSet.empty
 
 let declared_vars = function
-  | Decl_const (x, _)
-  | Decl_mut (x, _) -> VarSet.singleton x
+  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var x)
+  | Decl_mut (x, _) -> TypedVarSet.singleton (Mut_var x)
   | (Assign _
     | Branch _
     | Label _
@@ -113,7 +168,7 @@ let declared_vars = function
     | Invalidate _
     | Comment _
     | EndOpt
-    | Stop) -> VarSet.empty
+    | Stop) -> TypedVarSet.empty
 
 (* Which variables need to be in scope
  * Producer: declared_vars *)
@@ -133,10 +188,10 @@ let required_vars = function
   | Stop -> VarSet.empty
 
 let defined_vars = function
-  | Decl_const (x, _)
+  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var x)
   | Decl_mut (x, Some _)
   | Assign (x ,_)
-  | Read x -> VarSet.singleton x
+  | Read x -> TypedVarSet.singleton (Mut_var x)
   | Decl_mut (_, None)
   | Branch _
   | Label _
@@ -145,7 +200,7 @@ let defined_vars = function
   | Print _
   | Invalidate _
   | EndOpt
-  | Stop -> VarSet.empty
+  | Stop -> TypedVarSet.empty
 
 (* Which variables need to be defined
  * Producer: defined_vars *)
@@ -171,7 +226,7 @@ type scope_annotation =
 
 type inferred_scope =
   | Dead
-  | Scope of VarSet.t
+  | Scope of TypedVarSet.t
 
 type program = { instructions : instruction_stream; annotations : scope_annotation option array }
 

--- a/lexer.mll
+++ b/lexer.mll
@@ -12,6 +12,7 @@ let keyword_table = [
   "invalidate", INVALIDATE;
   "stop", STOP;
   "read", READ;
+  "end_opt", END_OPT;
 ]
 
 let id_or_keyword id =

--- a/parse.ml
+++ b/parse.ml
@@ -7,7 +7,7 @@ and message = string
 
 exception Error of parse_error
 
-let parse lexbuf =
+let parse lexbuf : Instr.program =
   (* see the Menhir manual for the description of
      error messages support *)
   let open MenhirLib.General in
@@ -31,11 +31,11 @@ let parse lexbuf =
       (Parser.Incremental.program lexbuf.Lexing.lex_curr_p)
   with Lexer.Error (input, pos) -> raise (Error (Lexing (input, pos)))
 
-let parse_string str =
+let parse_string str : Instr.program =
   let lexbuf = Lexing.from_string str in
   parse lexbuf
 
-let parse_file path =
+let parse_file path : Instr.program =
   let chan = open_in path in
   let lexbuf =
     let open Lexing in

--- a/parse.mli
+++ b/parse.mli
@@ -7,8 +7,8 @@ exception Error of parse_error
 (** The two functions below may raise this exception
     -- and no other. *)
 
-val parse_string : string -> Instr.annotated_program
-val parse_file : string -> Instr.annotated_program
+val parse_string : string -> Instr.program
+val parse_file : string -> Instr.program
 
 val report_error : parse_error -> unit
 (** Prints a user-friendly error message on the standard error ouput *)

--- a/parser.mly
+++ b/parser.mly
@@ -5,12 +5,12 @@
 %token DOUBLE_EQUAL NOT_EQUAL PLUS /* MINUS TIMES LT LTE GT GTE */
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
-%token CONST MUT BRANCH GOTO PRINT INVALIDATE STOP READ
+%token CONST MUT BRANCH GOTO PRINT INVALIDATE STOP READ END_OPT
 %token<string> COMMENT
 %token NEWLINE
 %token EOF
 
-%start<Instr.annotated_program> program
+%start<Instr.program> program
 
 %{ open Instr
 
@@ -28,8 +28,8 @@ program:
 | optional_newlines prog=list(instruction_line) EOF
   {
     let annotations, instructions = List.split prog in
-    (Array.of_list instructions,
-     Array.of_list annotations)
+    { instructions = Array.of_list instructions;
+      annotations = Array.of_list annotations }
   }
 
 instruction_line:
@@ -71,6 +71,8 @@ instruction:
   { Invalidate (e, l, xs) }
 | STOP
   { Stop }
+| END_OPT
+  { EndOpt }
 | s=COMMENT
   { Comment s }
 

--- a/parser.mly
+++ b/parser.mly
@@ -67,8 +67,12 @@ instruction:
   { Print e }
 | INVALIDATE
   e=expression l=label
-  xs=delimited(LBRACKET, separated_list(COMMA, variable), RBRACKET)
-  { Invalidate (e, l, xs) }
+  LBRACKET
+  out_scope=separated_list(COMMA, variable)
+  EQUAL
+  in_scope=separated_list(COMMA, variable)
+  RBRACKET
+  { Invalidate (e, l, { captured = in_scope; out = out_scope }) }
 | STOP
   { Stop }
 | END_OPT

--- a/scope.ml
+++ b/scope.ml
@@ -4,9 +4,9 @@ open Instr
     - keep track of const/mut status
 *)
 
-exception UndeclaredVariable of VarSet.t
-exception UninitializedVariable of VarSet.t
-exception DuplicateVariable of VarSet.t
+exception UndeclaredVariable of pc * VarSet.t
+exception UninitializedVariable of pc * VarSet.t
+exception DuplicateVariable of pc * VarSet.t
 
 type scope_info = { declared : VarSet.t; defined : VarSet.t }
 module ScopeInfo = struct
@@ -19,40 +19,44 @@ module ScopeInfo = struct
                   VarSet.equal a.defined b.defined
 end
 
-let no_annotations program : annotated_program =
-  (program, Array.map (fun _ -> None) program)
+let no_annotations (code : instruction_stream) : program  =
+  { instructions = code; annotations = Array.map (fun _ -> None) code }
 
 (* Internally we keep track of the declared and defined variables.
  * The output scopes and the annotations contain only the declarations. But
  * internally infer asserts that undefined variables are never used and
  * declarations do not shadow a previous one
  *)
-let infer (program : annotated_program) : inferred_scope array =
-  let instructions = fst program in
-  let annotations = snd program in
+let generic_infer update (code : program) : inferred_scope array =
+  let instructions = code.instructions in
+  let annotations = code.annotations in
   let open Analysis in
   let merge cur incom =
     let merged = ScopeInfo.inter cur incom in
     if ScopeInfo.equal cur merged then None else Some merged in
-  let update pc cur =
-    let annot = annotations.(pc) in
+  let update pc incomming =
+    (* Verify new declarations do not shadow existing ones *)
     let instr = instructions.(pc) in
-    let update = { declared = Instr.declared_vars instr;
-                   defined = Instr.defined_vars instr } in
-    let shadowed = VarSet.inter cur.declared update.declared in
-    if not (VarSet.is_empty shadowed) then raise (DuplicateVariable shadowed)
+    let created = { declared = Instr.declared_vars instr;
+                    defined = Instr.defined_vars instr } in
+    let shadowed = VarSet.inter incomming.declared created.declared in
+    if not (VarSet.is_empty shadowed) then raise (DuplicateVariable (pc, shadowed))
     else
-      let cur =
-        { cur with
-          declared = begin match annot with
-            | None | Some (At_least _) -> cur.declared
-            | Some (Exact constraints) ->
-              VarSet.inter cur.declared constraints
-          end
-        } in
-      ScopeInfo.union cur update in
-  let initial_state = {declared = VarSet.empty; defined = VarSet.empty} in
-  let res = Analysis.forward_analysis initial_state instructions merge update in
+      (* Remove incomming variables which are excluded by the annotations
+       * (The actual checking of scope annotations happens later) *)
+      let annot = annotations.(pc) in
+      let incomming' =
+      { incomming with
+        declared = begin match annot with
+          | None | Some (At_least _) -> incomming.declared
+          | Some (Exact constraints) ->
+             VarSet.inter incomming.declared constraints
+        end
+      } in
+      update instructions pc incomming' created
+  in
+  let initial_state = [({declared = VarSet.empty; defined = VarSet.empty}, 0)] in
+  let res = Analysis.dataflow_analysis initial_state instructions merge update in
   let finish pc res =
     let annotation = annotations.(pc) in
     let instr = instructions.(pc) in
@@ -61,7 +65,7 @@ let infer (program : annotated_program) : inferred_scope array =
     | Some res ->
       let must_have_declared vars =
         if not (VarSet.subset vars res.declared)
-        then raise (UndeclaredVariable (VarSet.diff vars res.declared)) in
+        then raise (UndeclaredVariable (pc, (VarSet.diff vars res.declared))) in
       must_have_declared (Instr.required_vars instr);
       begin match annotation with
         | None -> ()
@@ -69,8 +73,39 @@ let infer (program : annotated_program) : inferred_scope array =
       end;
       let must_have_defined vars =
         if not (VarSet.subset vars res.defined)
-        then raise (UninitializedVariable (VarSet.diff vars res.defined)) in
+        then raise (UninitializedVariable (pc, (VarSet.diff vars res.defined))) in
       must_have_defined (Instr.used_vars instr);
       Scope res.declared
   in
   Array.mapi finish res
+
+let infer (code : program) : inferred_scope array =
+  let update code pc incomming created =
+    let updated = ScopeInfo.union incomming created in
+    let succ = Analysis.successors code pc in
+    List.map (fun pc -> (updated, pc)) succ
+  in
+  generic_infer update code
+
+(* Only if we have the whole program we can follow invalidate labels *)
+let check_whole_program (code : program) =
+  let update code pc incomming created =
+    let updated = ScopeInfo.union incomming created in
+    let instr = code.(pc) in
+    match[@warning "-4"] instr with
+    | Invalidate (_exp, br, scope) ->
+      (* The Invalidate instruction continues in a new context,
+       * only explicitly captured variables are preserved. *)
+      let scope = VarSet.of_list scope in
+      let pc_next, pc_deopt = pc+1, resolve code br in
+      let deopt_frame = {
+        declared = VarSet.inter updated.declared scope;
+        defined = VarSet.inter updated.defined scope } in
+      [(updated, pc_next); (deopt_frame, pc_deopt)]
+    | _ ->
+      let succ = Analysis.successors code pc in
+      List.map (fun pc -> (updated, pc)) succ
+  in
+  ignore (generic_infer update code)
+
+

--- a/scope.ml
+++ b/scope.ml
@@ -19,6 +19,9 @@ module ScopeInfo = struct
                   VarSet.equal a.defined b.defined
 end
 
+let no_annotations program : annotated_program =
+  (program, Array.map (fun _ -> None) program)
+
 (* Internally we keep track of the declared and defined variables.
  * The output scopes and the annotations contain only the declarations. But
  * internally infer asserts that undefined variables are never used and
@@ -71,4 +74,3 @@ let infer (program : annotated_program) : inferred_scope array =
       Scope res.declared
   in
   Array.mapi finish res
-

--- a/scope.ml
+++ b/scope.ml
@@ -106,12 +106,12 @@ let check_whole_program (code : program) =
     | Invalidate (_exp, br, scope) ->
       (* The Invalidate instruction continues in a new context,
        * only explicitly captured variables are preserved. *)
-      let scope = VarSet.of_list scope in
+      let new_scope = VarSet.of_list scope.out in
       let pc_next, pc_deopt = pc+1, resolve code br in
       let deopt_frame = {
-        declared = TypedVarSet.inter_untyped updated.declared scope;
-        defined = TypedVarSet.inter_untyped updated.defined scope;
-        osr = scope } in
+        declared = TypedVarSet.inter_untyped updated.declared new_scope;
+        defined = TypedVarSet.inter_untyped updated.defined new_scope;
+        osr = new_scope } in
       [(updated, pc_next); (deopt_frame, pc_deopt)]
     | _ ->
       let succ = Analysis.successors code pc in

--- a/sourir.ml
+++ b/sourir.ml
@@ -40,14 +40,14 @@ let () =
         let program = if Array.exists (fun arg -> arg = "--prune") Sys.argv
           then
             let opt = Transform.branch_prune (program, scopes) in
-            let () = Printf.printf "%s" (Disasm.disassemble opt) in
+            let () = Printf.printf "\nAfter branch pruning:\n%s\n" (Disasm.disassemble opt) in
             opt
           else program
         in
         let program = if Array.exists (fun arg -> arg = "--cm") Sys.argv
           then
             let opt = Codemotion.apply program in
-            let () = Printf.printf "%s" (Disasm.disassemble opt) in
+            let () = Printf.printf "\nAfter code motion:\n%s\n" (Disasm.disassemble opt) in
             opt
           else program
         in

--- a/sourir.ml
+++ b/sourir.ml
@@ -37,9 +37,16 @@ let () =
         exit 1
       | scopes ->
         let program = fst annotated_program in
-        let program = if ((Array.length Sys.argv > 2) && (Sys.argv.(2) = "--prune"))
+        let program = if Array.exists (fun arg -> arg = "--prune") Sys.argv
           then
             let opt = Transform.branch_prune (program, scopes) in
+            let () = Printf.printf "%s" (Disasm.disassemble opt) in
+            opt
+          else program
+        in
+        let program = if Array.exists (fun arg -> arg = "--cm") Sys.argv
+          then
+            let opt = Codemotion.apply program in
             let () = Printf.printf "%s" (Disasm.disassemble opt) in
             opt
           else program

--- a/sourir.ml
+++ b/sourir.ml
@@ -41,18 +41,18 @@ let () =
         end;
         exit 1
       | scopes ->
+        let quiet = Array.exists (fun arg -> arg = "--quiet") Sys.argv in
         let program = if Array.exists (fun arg -> arg = "--prune") Sys.argv
           then
             let opt = Transform.branch_prune program in
-            let () = Printf.printf "\nAfter branch pruning:\n%s\n" (Disasm.disassemble opt) in
+            if not quiet then Printf.printf "\nAfter branch pruning:\n%s\n" (Disasm.disassemble opt);
             opt
           else program
         in
         let program = if Array.exists (fun arg -> arg = "--cm") Sys.argv
           then
-            let () = Printf.printf "\nBefore code motion:\n%s\n" (Disasm.disassemble program) in
             let opt = Codemotion.apply program in
-            let () = Printf.printf "\nAfter code motion:\n%s\n" (Disasm.disassemble opt) in
+            if not quiet then Printf.printf "\nAfter code motion:\n%s\n" (Disasm.disassemble opt);
             opt
           else program
         in

--- a/sourir.ml
+++ b/sourir.ml
@@ -50,8 +50,9 @@ let () =
         in
         let program = if Array.exists (fun arg -> arg = "--cm") Sys.argv
           then
+            let () = Printf.printf "\nBefore code motion:\n%s\n" (Disasm.disassemble program) in
             let opt = Codemotion.apply program in
-            let () = Printf.printf "\nAfter program motion:\n%s\n" (Disasm.disassemble opt) in
+            let () = Printf.printf "\nAfter code motion:\n%s\n" (Disasm.disassemble opt) in
             opt
           else program
         in

--- a/sourir.mllib
+++ b/sourir.mllib
@@ -9,3 +9,4 @@ Disasm
 Analysis
 Transform
 Cfg
+Codemotion

--- a/sourir.mllib
+++ b/sourir.mllib
@@ -8,3 +8,4 @@ Eval
 Disasm
 Analysis
 Transform
+Cfg

--- a/tests.ml
+++ b/tests.ml
@@ -336,7 +336,6 @@ let test_branch_pruning_exp (prog : program) expected =
 let test_branch_pruning (prog : program) deopt =
   let open Eval in
   let prog2 = Transform.branch_prune prog in
-  Printf.printf "%s\n" (Disasm.disassemble prog2);
   Scope.check_whole_program prog;
   Scope.check_whole_program prog2;
   run_checked prog no_input (fun res1 ->
@@ -656,7 +655,7 @@ let suite =
    "parser3">:: test_parse_disasm ("const x = (y + x)\n");
    "parser4">:: test_parse_disasm ("x <- (x == y)\n");
    "parser5">:: test_parse_disasm ("# asdfasdf\n");
-   "parser5b">:: test_parse_disasm ("invalidate (x == y) l [x, y, z]\nl:\n");
+   "parser5b">:: test_parse_disasm ("invalidate (x == y) l [x, y, z = a, b, c]\nl:\n");
    "parser6">:: test_parse_disasm ("branch (x == y) as fd\n");
    "parser7">:: test_parse_disasm ("const x = (y + x)\n x <- (x == y)\n# asdfasdf\nbranch (x == y) as fd\n");
    "parser8">:: test_parse_disasm_file "examples/sum.sou";

--- a/tests.ml
+++ b/tests.ml
@@ -359,6 +359,49 @@ l2:
 l3:
 ")
 
+let do_test_dom1 = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program test_df in
+  let doms = dominators (test_df, cfg) in
+  let expected = [| []; [0]; [0;1]; [0;1;2]; |] in
+  let got = Array.map (fun s ->
+    List.map (fun n -> n.id) (BasicBlockSet.elements s)) doms in
+  assert_equal got expected;
+  let c1 = common_dominator (test_df, cfg, doms) [8; 14] in
+  let c2 = common_dominator (test_df, cfg, doms) [8; 13] in
+  let c3 = common_dominator (test_df, cfg, doms) [12; 13] in
+  assert_equal c1.id 1;
+  assert_equal c2.id 1;
+  assert_equal c3.id 2
+
+(* compare a CFG against a blueprint. The blueprint uses
+ * array indices as successors instead of references to the
+ * successor BB.
+ * This is required since otherwise it is (i) annoying to
+ * construct the expected CFG and (ii) assert_equals diverges
+ * on circular CFGs *)
+type bb_blueprint = {entry : pc; exit : pc; succ : int list}
+let compare_cfg (cfg : Cfg.cfg) (cfg_blueprint : bb_blueprint array) =
+  let open Cfg in
+  assert_equal (Array.length cfg) (Array.length cfg_blueprint);
+  Array.iteri (fun i (expected : bb_blueprint) ->
+      let node = cfg.(i) in
+      assert_equal expected.entry node.entry;
+      assert_equal expected.exit node.exit;
+      let succ = List.map (fun n -> n.id) node.succ in
+      assert_equal expected.succ succ
+    ) cfg_blueprint
+
+let do_test_cfg = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program test_df in
+  let expected = [|
+      {entry=0; exit=5; succ=[1]};
+      {entry=6; exit=9; succ=[1;2]};
+      {entry=11; exit=13; succ=[1;3]};
+      {entry=14; exit=14; succ=[]} |] in
+  compare_cfg cfg expected
+
 let do_test_liveness = function () ->
   let open Analysis in
   let live = live test_df in
@@ -405,6 +448,51 @@ let do_test_reaching = function () ->
   assert_equal_sorted (InstrSet.elements (reaching 7)) [8;0;4];
   assert_equal_sorted (InstrSet.elements (reaching 12)) [8;7];
   assert_equal_sorted (InstrSet.elements (reaching 0)) []
+
+let test_df2 = fst (Parse.parse_string
+" goto jmp
+start:
+  mut i = 1
+  mut c = 0
+  mut v = 123
+  mut x = 0
+  loop:
+    branch (i==10) loop_end loop_begin
+  loop_begin:
+    mut w = 3
+    branch (c==2) tr fs
+    tr:
+      w <- 3
+      goto ct
+    fs:
+      branch (c==4) tr2 fs2
+      tr2:
+        stop
+    fs2:
+      w <- 4
+      goto ct
+  ct:
+    x <- w
+    v <- (c+1)
+    i <- (i+v)
+    goto loop
+loop_end:
+  print i
+  print x
+  # bla
+  goto end
+jmp:
+  branch true start end
+end:
+")
+
+let do_test_dom prog = function () ->
+  let open Cfg in
+  let cfg = Cfg.of_program prog in
+  let doms = dominators (prog, cfg) in
+  let c = common_dominator (test_df2, cfg, doms) [12; 19] in
+  let expected = Cfg.node_at cfg 9 in
+  assert_equal c.id expected.id
 
 let suite =
   let open Assembler in
@@ -478,6 +566,9 @@ let suite =
    "reaching">:: do_test_reaching;
    "used">:: do_test_used;
    "liveness">:: do_test_liveness;
+   "cfg">:: do_test_cfg;
+   "dom">:: do_test_dom1;
+   "dom2">:: do_test_dom test_df2;
    ]
 ;;
 

--- a/tests.ml
+++ b/tests.ml
@@ -487,11 +487,11 @@ end:
 ")
 
 let do_test_dom prog = function () ->
-  let open Cfg in
   let cfg = Cfg.of_program prog in
-  let doms = dominators (prog, cfg) in
-  let c = common_dominator (test_df2, cfg, doms) [12; 19] in
+  let doms = Cfg.dominators (prog, cfg) in
+  let c = Cfg.common_dominator (test_df2, cfg, doms) [12; 19] in
   let expected = Cfg.node_at cfg 9 in
+  let open Cfg in
   assert_equal c.id expected.id
 
 let suite =

--- a/transform.ml
+++ b/transform.ml
@@ -7,6 +7,7 @@ let remove_empty_jmp prog =
     let pc' = pc + 1 in
     if pc' = Array.length prog then [prog.(pc)] else
       match[@warning "-4"] (prog.(pc), prog.(pc')) with
+      | EndOpt, _ -> Array.to_list (Array.sub prog pc ((Array.length prog) - pc))
       | (Goto l1, Label l2) when l1 = l2 && List.length pred.(pc') = 1 ->
           remove_empty_jmp (pc+2)
       | (Label _, _) when pred.(pc) = [pc-1] && succ (pc-1) = [pc] ->
@@ -21,16 +22,18 @@ let remove_empty_jmp prog =
   in
   remove_empty_jmp 0
 
-let remove_dead_code prog entry=
+let remove_dead_code prog entry =
   let dead_code =
     let merge _ _ = None in
     let update _ _ = () in
-    Analysis.forward_analysis_from entry () prog merge update
+    Analysis.symmetric_forward_analysis_from entry () prog merge update
   in
   let rec remove_dead_code pc =
     let pc' = pc+1 in
-    if pc = Array.length prog then [] else
+    if pc = Array.length prog then []
+    else
       match[@warning "-4"] dead_code.(pc), prog.(pc) with
+      | _, EndOpt -> Array.to_list (Array.sub prog pc ((Array.length prog) - pc))
       (* Comments are considered live, if the next instruction is live.
        * This prevents removing comments above jump labels *)
       | None, Comment c ->
@@ -95,25 +98,27 @@ let copy_fresh global_labels prog =
       | Branch (exp, l1, l2) -> Branch (exp, map l1, map l2) :: copy pc'
       | Invalidate (exp, l, sc) -> Invalidate (exp, map l, sc) :: copy pc'
       | (Decl_const _ | Decl_mut _ | Assign _
-        | Read _ | Print _ | Stop | Comment _) as i -> i :: copy pc'
+        | Read _ | Print _ | EndOpt | Stop | Comment _) as i -> i :: copy pc'
   in
   let new_labels = LabelSet.map map prog_labels in
   let new_all_labels = LabelSet.union all_labels new_labels in
   (new_all_labels, Array.of_list (copy 0))
 
-let branch_prune (prog, scope) =
-  let live_at = Analysis.live prog in
+let branch_prune (prog : program) : program =
+  let scope = Scope.infer prog in
+  let code = prog.instructions in
+  let live_at = Analysis.live code in
   let rec branch_prune pc used_labels pruned landing_pads =
-    if pc = Array.length prog then (pruned, landing_pads) else
+    if pc = Array.length code then (pruned, landing_pads) else
+    let pc' = pc + 1 in
     match scope.(pc) with
-    | Dead -> assert(false)
+    | Dead -> branch_prune pc' used_labels (code.(pc) :: pruned) landing_pads
     | Scope scope ->
-      let pc' = pc + 1 in
-      begin match[@warning "-4"] prog.(pc) with
+      begin match[@warning "-4"] code.(pc) with
       | Branch (exp, l1, l2) ->
         (* 1. Copy the program with fresh labels for the landing pad *)
-        let used_labels, landing_pad = copy_fresh used_labels prog in
-        let entry = resolve prog l2 in
+        let used_labels, landing_pad = copy_fresh used_labels code in
+        let entry = resolve code l2 in
         let deopt_label = next_fresh_label used_labels ("deopt_" ^ l2) in
         let used_labels = LabelSet.add deopt_label used_labels in
         (* 2. Get the scoping information for the deopt:
@@ -127,8 +132,7 @@ let branch_prune (prog, scope) =
           (* program before entry point *)
           Array.sub landing_pad 0 entry;
           (* deoptimization target label *)
-          [| Comment ("Landing pad for " ^ deopt_label);
-             Label deopt_label |];
+          [| Label deopt_label |];
           (* recreate the frame: dead variables might be assigned in the continuation *)
           create_frame;
           (* rest of the program *)
@@ -138,7 +142,9 @@ let branch_prune (prog, scope) =
         ] in
         (* 4. Trim the landing pad to contain only the continuation
          *    part reachable from the entry label *)
-        let cont = Array.of_list (remove_dead_code landing_pad entry) in
+        let cont = Array.of_list (
+            Comment ("Landing pad for " ^ deopt_label) ::
+            remove_dead_code landing_pad entry) in
         (* 5. Replace the branch instruction by an invalidate *)
         let pruned = Invalidate (exp, deopt_label, live) :: pruned in
         let pruned = Goto l1 :: pruned in
@@ -151,7 +157,7 @@ let branch_prune (prog, scope) =
   (* In case the program does not end in a stop this is needed to not fall
    * through into the landing pads *)
   let rev_pruned = Stop :: rev_pruned in
-  let final = Array.of_list (List.rev rev_pruned) in
-  let combined = Array.concat (final :: landing_pads) in
-  let cleanup = Array.of_list (remove_dead_code combined 0) in
-  Array.of_list (remove_empty_jmp cleanup)
+  let pruned = Array.of_list (List.rev rev_pruned) in
+  let cleaned = Array.of_list (remove_dead_code pruned 0) in
+  let final = Array.of_list (remove_empty_jmp cleaned) in
+  Scope.no_annotations (Array.concat (final :: [| EndOpt |] :: landing_pads))

--- a/transform.ml
+++ b/transform.ml
@@ -183,7 +183,7 @@ let branch_prune (prog : program) : program =
         let dead = Instr.VarSet.diff muts_in_scope (Instr.VarSet.of_list live) in
         let cont = lift_declarations cont' 2 dead in
         (* 5. Replace the branch instruction by an invalidate *)
-        let pruned = Invalidate (exp, deopt_label_entry, live) :: pruned in
+        let pruned = Invalidate (exp, deopt_label_entry, {captured = live; out = live}) :: pruned in
         let pruned = Goto l1 :: pruned in
         let landing_pads = cont :: landing_pads in
         branch_prune pc' used_labels pruned landing_pads


### PR DESCRIPTION
sorry for this crazy big PR! I think it would be hard to entangle it. I can walk you through the changes though...

1. needs cfg. therefore its based on #34 
2. deals with the fact that we might have an already optimized program as input. we do not want to revisit the deopt targets (first of all pruning this code was our initial goal. secondly the invalidate is not symmetric in both branches (ie. the scope in the deopt case is different)) See commit ff00ac9 for the details.
3. fixes the scope of landing pads: this was horribly broken, see a5d5772 for the details
4. finally implements codemotion. for correct codemotion we need to be able to rename variables. since we want to be able to do this in the main program only and not in the deopt code I extended invalidate to support different in- and out- scopes