### PR TITLE
Moded variables

### DIFF
--- a/analysis.ml
+++ b/analysis.ml
@@ -131,7 +131,7 @@ let reaching (seg : segment) : pc -> InstrSet.t =
   let update pc defs =
     let instr = instrs.(pc) in
     (* add or override defined vars in one go*)
-    let kill = VarSet.elements (TypedVarSet.untyped (defined_vars instr)) in
+    let kill = VarSet.elements (ModedVarSet.untyped (defined_vars instr)) in
     let loc = InstrSet.singleton pc in
     let replace acc var = VariableMap.add var loc acc in
     List.fold_left replace defs kill
@@ -157,7 +157,7 @@ let liveness_analysis (seg : segment) =
   let update pc uses =
     let instr = instrs.(pc) in
     (* First remove defined vars *)
-    let kill = VarSet.elements (TypedVarSet.untyped (defined_vars instr)) in
+    let kill = VarSet.elements (ModedVarSet.untyped (defined_vars instr)) in
     let remove acc var = VariableMap.remove var acc in
     let uses = List.fold_left remove uses kill in
     (* Then add used vars *)
@@ -189,7 +189,7 @@ let used (seg : segment) : pc -> InstrSet.t =
     match res.(pc) with
     | None -> raise (DeadCode pc)
     | Some res ->
-        let defined = VarSet.elements (TypedVarSet.untyped (defined_vars instr)) in
+        let defined = VarSet.elements (ModedVarSet.untyped (defined_vars instr)) in
         let uses_of var = VariableMap.at var res in
         let all_uses = List.map uses_of defined in
         List.fold_left InstrSet.union InstrSet.empty all_uses

--- a/instr.ml
+++ b/instr.ml
@@ -105,12 +105,12 @@ module VarSet = Set.Make(Variable)
 
 type variable_type = Mut_var | Const_var
 
-type typed_var = variable_type * variable
+type moded_var = variable_type * variable
 
 exception Incomparable
 
-module TypedVar = struct
-  type t = typed_var
+module ModedVar = struct
+  type t = moded_var
   let compare (ma, a) (mb, b) =
     match String.compare a b with
     | 0 ->
@@ -118,8 +118,8 @@ module TypedVar = struct
     | c -> c
 end
 
-module TypedVarSet = struct
-  include Set.Make(TypedVar)
+module ModedVarSet = struct
+  include Set.Make(ModedVar)
 
   let vars set = List.map snd (elements set)
   let untyped set = VarSet.of_list (vars set)
@@ -146,8 +146,8 @@ let expr_vars = function
     |> List.fold_left VarSet.union VarSet.empty
 
 let declared_vars = function
-  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var, x)
-  | Decl_mut (x, _) -> TypedVarSet.singleton (Mut_var, x)
+  | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
+  | Decl_mut (x, _) -> ModedVarSet.singleton (Mut_var, x)
   | (Assign _
     | Drop _
     | Clear _
@@ -158,7 +158,7 @@ let declared_vars = function
     | Print _
     | Osr _
     | Comment _
-    | Stop) -> TypedVarSet.empty
+    | Stop) -> ModedVarSet.empty
 
 (* Which variables need to be in scope
  * Producer: declared_vars *)
@@ -182,10 +182,10 @@ let required_vars = function
   | Stop -> VarSet.empty
 
 let defined_vars = function
-  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var, x)
+  | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
   | Decl_mut (x, Some _)
   | Assign (x ,_)
-  | Read x -> TypedVarSet.singleton (Mut_var, x)
+  | Read x -> ModedVarSet.singleton (Mut_var, x)
   | Decl_mut (_, None)
   | Drop _
   | Clear _
@@ -195,7 +195,7 @@ let defined_vars = function
   | Comment _
   | Print _
   | Osr _
-  | Stop -> TypedVarSet.empty
+  | Stop -> ModedVarSet.empty
 
 let dropped_vars = function
   | Drop x -> VarSet.singleton x
@@ -258,7 +258,7 @@ type scope_annotation =
 
 type inferred_scope =
   | Dead
-  | Scope of TypedVarSet.t
+  | Scope of ModedVarSet.t
 
 type segment = instruction_stream * scope_annotation option array
 type program = (string * segment) list

--- a/instr.ml
+++ b/instr.ml
@@ -103,59 +103,36 @@ let resolve (code : instruction_stream) (label : string) =
 
 module VarSet = Set.Make(Variable)
 
-type typed_var =
-  | Mut_var of string
-  | Const_var of string
+type variable_type = Mut_var | Const_var
+
+type typed_var = variable_type * variable
 
 exception Incomparable
 
 module TypedVar = struct
   type t = typed_var
-  let compare a b =
-    match (a,b) with
-    | Mut_var   a, Mut_var   b
-    | Const_var a, Const_var b -> String.compare a b
-    | Mut_var   a, Const_var b
-    | Const_var a, Mut_var   b ->
-      if a = b then raise Incomparable else String.compare a b
+  let compare (ma, a) (mb, b) =
+    match String.compare a b with
+    | 0 ->
+      if ma = mb then 0 else raise Incomparable
+    | c -> c
 end
 
 module TypedVarSet = struct
   include Set.Make(TypedVar)
 
-  let vars set =
-    List.map (fun v ->
-        match v with
-        | Mut_var x | Const_var x -> x)
-      (elements set)
-
+  let vars set = List.map snd (elements set)
   let untyped set = VarSet.of_list (vars set)
 
   let muts set =
-    let muts = filter (fun v ->
-        match v with
-        | Mut_var x -> true
-        | Const_var x -> false)
-      set in
+    let muts = filter (fun (m,v) -> m = Mut_var) set in
     untyped muts
 
   let diff_untyped typed untyped =
-    filter (fun e ->
-        match e with
-        | Mut_var x | Const_var x ->
-          begin match VarSet.find x untyped with
-            | exception Not_found -> true
-            | _ -> false
-          end) typed
+    filter (fun (_m, x) -> not (VarSet.mem x untyped)) typed
 
   let inter_untyped typed untyped =
-    filter (fun e ->
-        match e with
-        | Mut_var x | Const_var x ->
-          begin match VarSet.find x untyped with
-            | exception Not_found -> false
-            | _ -> true
-          end) typed
+    filter (fun (_m, x) -> VarSet.mem x untyped) typed
 end
 
 let simple_expr_vars = function
@@ -169,8 +146,8 @@ let expr_vars = function
     |> List.fold_left VarSet.union VarSet.empty
 
 let declared_vars = function
-  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var x)
-  | Decl_mut (x, _) -> TypedVarSet.singleton (Mut_var x)
+  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var, x)
+  | Decl_mut (x, _) -> TypedVarSet.singleton (Mut_var, x)
   | (Assign _
     | Drop _
     | Clear _
@@ -205,10 +182,10 @@ let required_vars = function
   | Stop -> VarSet.empty
 
 let defined_vars = function
-  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var x)
+  | Decl_const (x, _) -> TypedVarSet.singleton (Const_var, x)
   | Decl_mut (x, Some _)
   | Assign (x ,_)
-  | Read x -> TypedVarSet.singleton (Mut_var x)
+  | Read x -> TypedVarSet.singleton (Mut_var, x)
   | Decl_mut (_, None)
   | Drop _
   | Clear _

--- a/transform.ml
+++ b/transform.ml
@@ -64,9 +64,9 @@ let branch_prune (prog : program) : program =
         begin match[@warning "-4"] instrs.(pc), annots.(pc) with
         | Branch (exp, l1, l2), a ->
           let osr = List.map (function
-              | Const_var x ->
+              | (Const_var, x) ->
                 OsrConst (x, (Simple (Var x)))
-              | Mut_var x ->
+              | (Mut_var, x) ->
                 if List.exists (fun x' -> x = x') (live pc) then
                   OsrMut (x, x)
                 else

--- a/transform.ml
+++ b/transform.ml
@@ -71,7 +71,7 @@ let branch_prune (prog : program) : program =
                   OsrMut (x, x)
                 else
                   OsrMutUndef x)
-              (TypedVarSet.elements scope)
+              (ModedVarSet.elements scope)
           in
           branch_prune pc'
             (Goto l2 :: Osr (exp, deopt_label, l1, osr) :: acc_i)


### PR DESCRIPTION
These two commits do not change the implementation behavior, they are purely internal changes. I initially intended to get rid of `*_untyped` as a further commit in the branch, but I am not sure anymore that this is the best move, so I just kept these.