### PR TITLE
allow empty scope annotations {} and trailing commas {x, y,}

### DIFF
--- a/parser.mly
+++ b/parser.mly
@@ -58,6 +58,7 @@ optional_newlines: list(NEWLINE) { () }
 scope:
 | x=variable COMMA sc=scope { let (mode, xs) = sc in (mode, x::xs) }
 | x=variable { (`Exact, [x]) }
+| { (`Exact, []) }
 | TRIPLE_DOT { (`At_least, []) }
 
 osr_def:

--- a/tests.ml
+++ b/tests.ml
@@ -288,7 +288,7 @@ c:
 "
 
 let test_double_loop = parse_test
-"mut i
+"{} mut i
  i <- 0
  mut sum = 0
  const limit = 4
@@ -608,7 +608,7 @@ let suite =
 
 let () =
   let test_result = run_test_tt_main suite in
-  let is_success = function
+  let is_success = function[@warning "-4"]
     | RSuccess _ -> true
     | _ -> false in
   if not (List.for_all is_success test_result) then exit 1;;


### PR DESCRIPTION
fixes #55