### PR TITLE
Scope uninitialized

### DIFF
--- a/scope.ml
+++ b/scope.ml
@@ -51,7 +51,7 @@ exception IncompatibleScope of inference_state * inference_state * pc
 let infer instructions : inferred_scope array =
   let open Analysis in
   let merge pc cur incom =
-    if not (ScopeInfo.equal cur.info incom.info)
+    if not (ModedVarSet.equal cur.info.declared incom.info.declared)
     then raise (IncompatibleScope (cur, incom, pc))
     else if PcSet.equal cur.sources incom.sources then None
     else Some { info = cur.info; sources = PcSet.union cur.sources incom.sources }
@@ -160,7 +160,6 @@ let explain_incompatible_scope outchan s1 s2 pc =
           "  - the %s %s %a and the %s does not\n"
           name1 verb print_vars diff name2 in
     print_diff "declares" diff.declared;
-    print_diff "defines"  (ModedVarSet.diff diff.defined diff.declared);
   in
   Printf.bprintf buf
     "At instruction %d,\n\

--- a/scope.ml
+++ b/scope.ml
@@ -32,7 +32,6 @@ let drop_annots : annotated_program -> program =
   List.map (fun (name, (instrs, annot)) -> (name, instrs))
 
 exception IncompatibleScope of inference_state * inference_state * pc
-exception SometimesUninitialized of inference_state * inference_state * pc
 
 let infer instructions : inferred_scope array =
   let open Analysis in
@@ -62,25 +61,20 @@ let infer instructions : inferred_scope array =
 
   let check_initialized instructions =
     let merge pc cur incom =
-      if not (ModedVarSet.equal cur.info incom.info)
-      then raise (SometimesUninitialized (cur, incom, pc))
-      else if PcSet.equal cur.sources incom.sources then None
-      else Some { info = cur.info; sources = PcSet.union cur.sources incom.sources }
+      let merged = ModedVarSet.inter cur incom in
+      if ModedVarSet.equal cur merged then None else Some merged
     in
     let update pc cur =
       let instr = instructions.(pc) in
       let written = Instr.defined_vars instr in
-      let info = cur.info in
-      let updated = ModedVarSet.union info written in
+      let updated = ModedVarSet.union cur written in
       let dropped, cleared = Instr.dropped_vars instr, Instr.cleared_vars instr in
       (* dropped variables must also be undefined, to preserve the property
          that only declared variables are defined. *)
-      let final_info = ModedVarSet.diff_untyped updated (VarSet.union dropped cleared) in
-      { sources = PcSet.singleton pc; info = final_info; }
+      ModedVarSet.diff_untyped updated (VarSet.union dropped cleared)
     in
-    let initial_state = { sources = PcSet.empty; info = ModedVarSet.empty; } in
-    let res = Analysis.forward_analysis initial_state instructions merge update in
-    fun pc -> (res pc).info in
+    let initial_state = ModedVarSet.empty in
+    Analysis.forward_analysis initial_state instructions merge update in
 
   let inferred = infer_scope instructions in
   let initialized = check_initialized instructions in
@@ -122,7 +116,7 @@ let check (scope : inferred_scope array) annotations =
   in
   Array.iteri check_at scope
 
-let explain_incompatible_merge explanation_msg final_msg outchan s1 s2 pc =
+let explain_incompatible_scope outchan s1 s2 pc =
   let buf = Buffer.create 100 in
   let print_sep buf print_elem elems sep last_sep =
     let len = Array.length elems in
@@ -157,29 +151,18 @@ let explain_incompatible_merge explanation_msg final_msg outchan s1 s2 pc =
     let print_diff diff =
       if not (ModedVarSet.is_empty diff) then
         Printf.bprintf buf
-          final_msg name1 print_vars diff name2 in
+          "  - the %s declares %a and the %s does not\n"
+          name1 print_vars diff name2 in
     print_diff diff;
   in
   Printf.bprintf buf
-    explanation_msg
+    "At instruction %d,\n\
+     the scope coming from %a and\n\
+     the scope coming from %a\n\
+     are incompatible:\n"
     pc
     print_sources s1.sources
     print_sources s2.sources;
   print_only buf "former" (ModedVarSet.diff s1.info s2.info) "latter";
   print_only buf "latter" (ModedVarSet.diff s2.info s1.info) "former";
   Buffer.output_buffer outchan buf
-
-let explain_incompatible_scope outchan s1 s2 pc =
-  explain_incompatible_merge
-    "At instruction %d,\n\
-     the scope coming from %a and\n\
-     the scope coming from %a\n\
-     are incompatible:\n"
-    "  - the %s declares %a and the %s does not\n"
-    outchan s1 s2 pc
-
-let explain_incompatible_initialization outchan s1 s2 pc =
-  explain_incompatible_merge
-    "At instruction %d when control from %a and %a merges:\n"
-    " - in the %s branch %a is assigned to but in %s one it might be undefined\n"
-    outchan s1 s2 pc

--- a/scope.ml
+++ b/scope.ml
@@ -63,8 +63,10 @@ let infer instructions : inferred_scope array =
     fun pc -> (res pc).info in
 
   let check_initialized instructions =
-    let open Analysis in
-    let merge pc cur incom = assert (ModedVarSet.equal cur incom); None in
+    let merge pc cur incom =
+      let merge = ModedVarSet.inter cur incom in
+      if ModedVarSet.equal cur merge then None else Some merge
+    in
     let update pc cur =
       let instr = instructions.(pc) in
       let written = Instr.defined_vars instr in

--- a/scope.ml
+++ b/scope.ml
@@ -9,18 +9,7 @@ exception UninitializedVariable of VarSet.t * pc
 exception ExtraneousVariable of VarSet.t * pc
 exception DuplicateVariable of VarSet.t * pc
 
-type scope_info = { declared : ModedVarSet.t; defined : ModedVarSet.t }
-module ScopeInfo = struct
-  type t = scope_info
-  let inter a b = {declared = ModedVarSet.inter a.declared b.declared;
-                   defined  = ModedVarSet.inter a.defined b.defined}
-  let union a b = {declared = ModedVarSet.union a.declared b.declared;
-                   defined  = ModedVarSet.union a.defined b.defined}
-  let diff a b = {declared  = ModedVarSet.diff a.declared b.declared;
-                   defined  = ModedVarSet.diff a.defined b.defined}
-  let equal a b = ModedVarSet.equal a.declared b.declared &&
-                  ModedVarSet.equal a.defined b.defined
-end
+type scope_info = ModedVarSet.t
 
 module PcSet = Set.Make(Pc)
 type inference_state = {
@@ -44,62 +33,67 @@ let drop_annots : annotated_program -> program =
 
 exception IncompatibleScope of inference_state * inference_state * pc
 
-(* Internally we keep track of the declared and defined variables.
- * We check that undefined variables are never used and
- * declarations do not shadow a previous one
- *)
 let infer instructions : inferred_scope array =
   let open Analysis in
-  let merge pc cur incom =
-    if not (ModedVarSet.equal cur.info.declared incom.info.declared)
-    then raise (IncompatibleScope (cur, incom, pc))
-    else if PcSet.equal cur.sources incom.sources then None
-    else Some { info = cur.info; sources = PcSet.union cur.sources incom.sources }
-  in
-  let update pc cur =
-    let instr = instructions.(pc) in
-    let added = {
-      declared = Instr.declared_vars instr;
-      defined = Instr.defined_vars instr;
+
+  let infer_scope instructions =
+    let merge pc cur incom =
+      if not (ModedVarSet.equal cur.info incom.info)
+      then raise (IncompatibleScope (cur, incom, pc))
+      else if PcSet.equal cur.sources incom.sources then None
+      else Some { info = cur.info; sources = PcSet.union cur.sources incom.sources }
+    in
+    let update pc cur =
+      let instr = instructions.(pc) in
+      let added = Instr.declared_vars instr in
+      let info = cur.info in
+      let shadowed = ModedVarSet.inter info added in
+      if not (ModedVarSet.is_empty shadowed) then
+        raise (DuplicateVariable (ModedVarSet.untyped shadowed, pc));
+      let updated = ModedVarSet.union info added in
+      let dropped = Instr.dropped_vars instr in
+      let final_info = ModedVarSet.diff_untyped updated dropped in
+      { sources = PcSet.singleton pc; info = final_info; }
+    in
+    let initial_state = {
+      sources = PcSet.empty;
+      info = ModedVarSet.empty;
     } in
-    let shadowed = ModedVarSet.inter cur.info.declared added.declared in
-    if not (ModedVarSet.is_empty shadowed) then
-      raise (DuplicateVariable (ModedVarSet.untyped shadowed, pc));
-    let info = cur.info in
-    let updated = ScopeInfo.union info added in
-    let dropped, cleared = Instr.dropped_vars instr, Instr.cleared_vars instr in
-    (* dropped variables must also be undefined, to preserve the property
-       that only declared variables are defined. *)
-    let final_info = {
-      declared = ModedVarSet.diff_untyped updated.declared dropped;
-      defined = ModedVarSet.diff_untyped updated.defined
-          (VarSet.union dropped cleared);
-    } in
-    { sources = PcSet.singleton pc; info = final_info; }
-  in
-  let initial_state = {
-    sources = PcSet.empty;
-    info = {declared = ModedVarSet.empty; defined = ModedVarSet.empty};
-  } in
-  let res = Analysis.forward_analysis initial_state instructions merge update in
-  let infer_at pc instr =
-    match res pc with
+    let res = Analysis.forward_analysis initial_state instructions merge update in
+    fun pc -> (res pc).info in
+
+  let check_initialized instructions =
+    let open Analysis in
+    let merge pc cur incom = assert (ModedVarSet.equal cur incom); None in
+    let update pc cur =
+      let instr = instructions.(pc) in
+      let written = Instr.defined_vars instr in
+      let updated = ModedVarSet.union cur written in
+      let dropped, cleared = Instr.dropped_vars instr, Instr.cleared_vars instr in
+      (* dropped variables must also be undefined, to preserve the property
+         that only declared variables are defined. *)
+      ModedVarSet.diff_untyped updated (VarSet.union dropped cleared)
+    in
+    Analysis.forward_analysis ModedVarSet.empty instructions merge update in
+
+  let inferred = infer_scope instructions in
+  let initialized = check_initialized instructions in
+
+  let resolve pc instr =
+    match inferred pc, initialized pc with
     | exception Analysis.UnreachableCode _ -> Dead
-    | { info; _ } ->
-      begin
-        let vars = Instr.required_vars instr in
-        let declared = ModedVarSet.untyped info.declared in
-        if not (VarSet.subset vars declared)
-        then raise (UndeclaredVariable (VarSet.diff vars declared, pc))
-      end;
-      begin
-        let vars = Instr.used_vars instr in
-        let defined = ModedVarSet.untyped info.defined in
-        if not (VarSet.subset vars defined)
-        then raise (UninitializedVariable (VarSet.diff vars defined, pc));
-      end;
-      Scope info.declared in
-  Array.mapi infer_at instructions
+    | declared, defined ->
+      let defined' = ModedVarSet.untyped defined in
+      let declared' = ModedVarSet.untyped declared in
+      let used = Instr.used_vars instr in
+      let required = Instr.required_vars instr in
+      if not (VarSet.subset required declared')
+      then raise (UndeclaredVariable (VarSet.diff required declared', pc));
+      if not (VarSet.subset used defined')
+      then raise (UninitializedVariable (VarSet.diff used defined', pc));
+      Scope defined in
+
+  Array.mapi resolve instructions
 
 let check (scope : inferred_scope array) annotations =
   let check_at pc scope =
@@ -159,7 +153,7 @@ let explain_incompatible_scope outchan s1 s2 pc =
         Printf.bprintf buf
           "  - the %s %s %a and the %s does not\n"
           name1 verb print_vars diff name2 in
-    print_diff "declares" diff.declared;
+    print_diff "declares" diff;
   in
   Printf.bprintf buf
     "At instruction %d,\n\
@@ -169,6 +163,6 @@ let explain_incompatible_scope outchan s1 s2 pc =
     pc
     print_sources s1.sources
     print_sources s2.sources;
-  print_only buf "former" (ScopeInfo.diff s1.info s2.info) "latter";
-  print_only buf "latter" (ScopeInfo.diff s2.info s1.info) "former";
+  print_only buf "former" (ModedVarSet.diff s1.info s2.info) "latter";
+  print_only buf "latter" (ModedVarSet.diff s2.info s1.info) "former";
   Buffer.output_buffer outchan buf

--- a/sourir.ml
+++ b/sourir.ml
@@ -33,10 +33,10 @@ let () =
         let l = pc+1 in
         begin match Instr.VarSet.elements xs with
           | [x] -> Printf.eprintf
-                     "%s:%d : Error: Variable %s might be uninitialized.\n%!"
+                     "%s:%d : Error: Variable %s is uninitialized.\n%!"
                      path l x
           | xs -> Printf.eprintf
-                    "%s:%d : Error: Variables {%s} might be uninitialized.\n%!"
+                    "%s:%d : Error: Variables {%s} is uninitialized.\n%!"
                     path l (String.concat ", " xs)
         end;
         exit 1
@@ -75,6 +75,11 @@ let () =
       | Scope.IncompatibleScope (scope1, scope2, pc) ->
         Disasm.pretty_print_segment stderr (name, instrs);
         Scope.explain_incompatible_scope stderr scope1 scope2 pc;
+        flush stderr;
+        exit 1
+      | Scope.SometimesUninitialized (scope1, scope2, pc) ->
+        Disasm.pretty_print_segment stderr (name, instrs);
+        Scope.explain_incompatible_initialization stderr scope1 scope2 pc;
         flush stderr;
         exit 1
       ) program;

--- a/sourir.ml
+++ b/sourir.ml
@@ -77,11 +77,6 @@ let () =
         Scope.explain_incompatible_scope stderr scope1 scope2 pc;
         flush stderr;
         exit 1
-      | Scope.SometimesUninitialized (scope1, scope2, pc) ->
-        Disasm.pretty_print_segment stderr (name, instrs);
-        Scope.explain_incompatible_initialization stderr scope1 scope2 pc;
-        flush stderr;
-        exit 1
       ) program;
 
       let program = Scope.drop_annots program in

--- a/tests.ml
+++ b/tests.ml
@@ -231,7 +231,20 @@ let do_test_scope_uninitialized = function () ->
     clearit:
      clear x
      goto loop
-    "))
+    "));
+  (* Positive example: even though one branch cleares x it is restored at the end *)
+  ignore (parse_test "
+     mut x = 1
+    loop:
+     print x
+     branch (x==1) clearit skip
+    clearit:
+     clear x
+    skip:
+     x <- 7
+     goto loop
+    ")
+
 
 
 

--- a/tests.ml
+++ b/tests.ml
@@ -215,6 +215,26 @@ let test_read_print_err_4 = parse_annotated
     print b
 "
 
+let do_test_scope_uninitialized = function () ->
+  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
+     mut x = 1
+    loop:
+     print x
+     clear x
+     goto loop
+    "));
+  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
+     mut x = 1
+    loop:
+     print x
+     branch (x==1) clearit loop
+    clearit:
+     clear x
+     goto loop
+    "))
+
+
+
 let undeclared missing_vars pos =
   Scope.UndeclaredVariable (VarSet.of_list missing_vars, pos)
 
@@ -573,6 +593,7 @@ let suite =
      (test_scope_1 "a" "c") (undeclared ["a"] 12);
    "scope1broken2">:: infer_broken_scope
      (test_scope_1 "a" "b") (undeclared ["b"; "a"] 12);
+   "scope_uninitialized">:: do_test_scope_uninitialized;
    "parser">:: test_parse_disasm ("segment main\nstop\n");
    "parser1">:: test_parse_disasm ("segment asdf\nconst x = 3\nprint x\nstop\n");
    "parser2">:: test_parse_disasm ("segment asdf\ngoto l\nx <- 3\nl:\n");

--- a/tests.ml
+++ b/tests.ml
@@ -216,14 +216,19 @@ let test_read_print_err_4 = parse_annotated
 "
 
 let do_test_scope_uninitialized = function () ->
-  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
+  begin match parse_test "
      mut x = 1
     loop:
      print x
      clear x
      goto loop
-    "));
-  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
+    " with
+  | exception Scope.SometimesUninitialized (_, _, pc) ->
+    assert (pc = 1)
+  | _ ->
+    assert false
+  end;
+  begin match parse_test "
      mut x = 1
     loop:
      print x
@@ -231,9 +236,13 @@ let do_test_scope_uninitialized = function () ->
     clearit:
      clear x
      goto loop
-    "));
-  (* Positive example: even though one branch cleares x it is restored at the end *)
-  ignore (parse_test "
+    " with
+  | exception Scope.SometimesUninitialized (_, _, pc) ->
+    assert (pc = 1)
+  | _ ->
+    assert false
+  end;
+  begin match parse_test "
      mut x = 1
     loop:
      print x
@@ -243,7 +252,12 @@ let do_test_scope_uninitialized = function () ->
     skip:
      x <- 7
      goto loop
-    ")
+    " with
+  | exception Scope.SometimesUninitialized (_, _, pc) ->
+    assert (pc = 6)
+  | _ ->
+    assert false
+  end
 
 
 

--- a/tests.ml
+++ b/tests.ml
@@ -216,19 +216,14 @@ let test_read_print_err_4 = parse_annotated
 "
 
 let do_test_scope_uninitialized = function () ->
-  begin match parse_test "
+  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
      mut x = 1
     loop:
      print x
      clear x
      goto loop
-    " with
-  | exception Scope.SometimesUninitialized (_, _, pc) ->
-    assert (pc = 1)
-  | _ ->
-    assert false
-  end;
-  begin match parse_test "
+    "));
+  assert_raises (Scope.UninitializedVariable (VarSet.singleton "x", 2)) (fun () -> ignore (parse_test "
      mut x = 1
     loop:
      print x
@@ -236,13 +231,9 @@ let do_test_scope_uninitialized = function () ->
     clearit:
      clear x
      goto loop
-    " with
-  | exception Scope.SometimesUninitialized (_, _, pc) ->
-    assert (pc = 1)
-  | _ ->
-    assert false
-  end;
-  begin match parse_test "
+    "));
+  (* Positive example: even though one branch cleares x it is restored at the end *)
+  ignore (parse_test "
      mut x = 1
     loop:
      print x
@@ -252,12 +243,7 @@ let do_test_scope_uninitialized = function () ->
     skip:
      x <- 7
      goto loop
-    " with
-  | exception Scope.SometimesUninitialized (_, _, pc) ->
-    assert (pc = 6)
-  | _ ->
-    assert false
-  end
+    ")
 
 
 


### PR DESCRIPTION
Initially I just wanted to fix a warning (see 336a468).

But then I realized that scope inference and checking for uninitialized variables really should be split into two independent steps