### PR TITLE
transformation to minimize lifetimes of variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,14 @@ TEMPDIR := $(shell mktemp -d)
 
 test_examples: sourir
 	mkdir $(TEMPDIR)/examples
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet                   > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --cm --prune      > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet                   > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --cm --prune      > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet \
+	  > $(TEMPDIR)/$$f.out; done
+	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --lifetime --cm --prune \
+	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet \
+	  > $(TEMPDIR)/$$f.out; done
+	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --lifetime --cm --prune \
+	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
 	rm -rf $(TEMPDIR)
 
 clean:

--- a/analysis.ml
+++ b/analysis.ml
@@ -177,26 +177,27 @@ let reaching (instrs : segment) : pc -> PcSet.t =
     let all_definitions = List.map definitions_of used in
     List.fold_left PcSet.union PcSet.empty all_definitions
 
-
-let liveness_analysis (instrs : segment) =
-  let merge _pc cur_uses in_uses =
-    let merged = VariableMap.union cur_uses in_uses in
-    if VariableMap.equal cur_uses merged then None else Some merged
+let scope_analysis (introduction : instruction -> variable list)
+                   (elimination : instruction -> variable list) (instrs : segment) =
+  let merge _pc cur_scope in_scope =
+    let merged = VariableMap.union cur_scope in_scope in
+    if VariableMap.equal cur_scope merged then None else Some merged
   in
-  let update pc uses =
+  let update pc cur_scope =
     let instr = instrs.(pc) in
-    (* First remove defined vars *)
-    let kill = VarSet.elements (ModedVarSet.untyped (defined_vars instr)) in
+    let to_remove = introduction instr in
     let remove acc var = VariableMap.remove var acc in
-    let uses = List.fold_left remove uses kill in
-    (* Then add used vars *)
-    let used = VarSet.elements (used_vars instr) in
-    let merge acc var = VariableMap.union (VariableMap.singleton var pc) acc
-    in
-    List.fold_left merge uses used
+    let cur_scope' = List.fold_left remove cur_scope to_remove in
+    let to_add = elimination instr in
+    let merge acc var = VariableMap.union (VariableMap.singleton var pc) acc in
+    List.fold_left merge cur_scope' to_add
   in
   backwards_analysis VariableMap.empty instrs merge update
 
+let liveness_analysis (instrs : segment) =
+  let introduction instr = VarSet.elements (ModedVarSet.untyped (defined_vars instr)) in
+  let elimination instr = VarSet.elements (used_vars instr) in
+  scope_analysis introduction elimination instrs
 
 (* returns a 'pc -> variable set' computing live vars at a certain pc *)
 let live (seg : segment) : pc -> variable list =
@@ -228,3 +229,38 @@ let dominates (instrs : segment) : pc -> pc -> bool =
   fun pc pc' ->
     let doms = dominators pc' in
     PcSet.exists ((=) pc) doms
+
+let lifetime_analysis (instrs : segment) =
+  let introduction instr = VarSet.elements (ModedVarSet.untyped (declared_vars instr)) in
+  let elimination instr = VarSet.elements (required_vars instr) in
+  scope_analysis introduction elimination instrs
+
+(* returns a 'pc -> pc set' computing the set of instructions depending on a declaration *)
+let required (instrs : segment) : pc -> PcSet.t =
+  let res = lifetime_analysis instrs in
+  fun pc ->
+    let instr = instrs.(pc) in
+    let declared = VarSet.elements (ModedVarSet.untyped (declared_vars instr)) in
+    let required_of var = VariableMap.at var (res pc) in
+    let all_requires = List.map required_of declared in
+    List.fold_left PcSet.union PcSet.empty all_requires
+
+(* returns a 'pc -> variable set' computing variables which need to be in scope
+ * Note: they might not be! *)
+let required_vars_at (seg : segment) : pc -> variable list =
+  let res = lifetime_analysis seg in
+  fun pc ->
+    let collect_key (key, value) = key in
+    let live_vars = List.map collect_key (VariableMap.bindings (res pc)) in
+    live_vars
+
+(* The same as required_vars_at but extends the required interval to
+ * merge points to conform to our scoping rules *)
+let required_merged_vars_at instrs =
+  let required_vars_at = required_vars_at instrs in
+  let merge pc cur_lifetime in_lifetime =
+    let merged = VarSet.union cur_lifetime in_lifetime in
+    if VarSet.equal cur_lifetime merged then None else Some merged
+  in
+  let update pc cur_lifetime = VarSet.of_list (required_vars_at pc) in
+  forward_analysis VarSet.empty instrs merge update

--- a/sourir.ml
+++ b/sourir.ml
@@ -16,6 +16,7 @@ let () =
     let quiet = Array.exists (fun arg -> arg = "--quiet") Sys.argv in
     let prune = Array.exists (fun arg -> arg = "--prune") Sys.argv in
     let codemotion = Array.exists (fun arg -> arg = "--cm") Sys.argv in
+    let lifetime = Array.exists (fun arg -> arg = "--lifetime") Sys.argv in
 
     List.iter (fun (name, (instrs, annot)) ->
       try Scope.check (Scope.infer instrs) annot with
@@ -97,5 +98,16 @@ let () =
           opt
         else program
       in
+
+      let program = if lifetime
+        then
+          let opt = Transform.minimize_lifetimes program in
+          if not quiet then Printf.printf "\n** After minimizing lifetimes:\n%s" (Disasm.disassemble opt);
+          opt
+        else program
+      in
+
+      List.iter (fun (name, instrs) ->
+        Scope.check (Scope.infer instrs) (Array.map (fun _ -> None) instrs)) program;
 
       ignore (Eval.run_interactive IO.stdin_input program)

--- a/transform.ml
+++ b/transform.ml
@@ -169,16 +169,17 @@ let minimize_lifetimes prog =
   let main = remove_unused_vars main in
   let main = remove_drops main in
   let predecessors = Analysis.predecessors main in
-  let required_at = Analysis.required_merged_vars_at main in
+  let required = Analysis.required_vars main in
+  let required = Analysis.saturate required main in
   let required_before pc =
     (* It might seem like we need to take the union over all predecessors. But
      * since required_merged_vars_at extends lifetimes to mergepoints this is
      * equivalent to just look at the first predecessor *)
-    match predecessors.(pc) with | [] -> VarSet.empty | p :: _ -> required_at p
+    match predecessors.(pc) with | [] -> VarSet.empty | p :: _ -> required p
   in
   let rec result (pc : pc) =
     if pc = Array.length main then [] else
-      let required = required_at pc in
+      let required = required pc in
       let required_before = required_before pc in
       let to_drop = VarSet.diff required_before required in
       let drops = List.map (fun x -> Drop x) (VarSet.elements to_drop) in


### PR DESCRIPTION
this transformation removes dead stores, dead declarations and places
drops to minimize the lifetime of variables according to the scoping
rules.