### PR TITLE
optimized branch pruning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ test_examples: sourir
 	mkdir $(TEMPDIR)/examples
 	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet \
 	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --lifetime --cm --prune \
+	for f in examples/*.sou; do echo $$f; yes 0 | ./sourir $$f --quiet --lifetime --cm --optprune \
 	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
 	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet \
 	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --lifetime --cm --prune \
+	for f in examples/*.sou; do echo $$f; yes 1 | ./sourir $$f --quiet --lifetime --cm --optprune \
 	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
 	rm -rf $(TEMPDIR)
 

--- a/examples/cm_possible_after_opt_prune.sou
+++ b/examples/cm_possible_after_opt_prune.sou
@@ -1,0 +1,27 @@
+  mut value
+  mut op
+  read value
+  read op
+  mut sum = 1
+  mut temp
+ loop_head:
+   branch (value == 10) end loop
+  loop:
+   branch (op == 1) op_1 check_op_1
+  check_op_1:
+   branch (op != 2) invalid_op op_2
+  invalid_op:
+   stop
+  op_1:
+   temp <- value
+   sum <- (sum+temp)
+   goto loop_tail
+  op_2:
+   temp <- 1
+   sum <- (sum+temp)
+   goto loop_tail
+ loop_tail:
+   value <- (value + 1)
+   goto loop_head
+ end:
+  print sum

--- a/instr.ml
+++ b/instr.ml
@@ -252,6 +252,21 @@ let used_vars = function
     let exps_vars = List.map expr_vars exps in
     List.fold_left VarSet.union (expr_vars e) exps_vars
 
+let changed_vars = function
+  | Decl_const (x, _)
+  | Decl_mut (x, _)
+  | Assign (x, _)
+  | Drop x
+  | Read x
+  | Clear x -> VarSet.singleton x
+  | Branch _
+  | Label _
+  | Goto _
+  | Comment _
+  | Print _
+  | Osr _
+  | Stop -> VarSet.empty
+
 type 'a dict = (string * 'a) list
 
 type segment = instruction_stream

--- a/sourir.ml
+++ b/sourir.ml
@@ -15,6 +15,7 @@ let () =
     in
     let quiet = Array.exists (fun arg -> arg = "--quiet") Sys.argv in
     let prune = Array.exists (fun arg -> arg = "--prune") Sys.argv in
+    let opt_prune = Array.exists (fun arg -> arg = "--optprune") Sys.argv in
     let codemotion = Array.exists (fun arg -> arg = "--cm") Sys.argv in
     let lifetime = Array.exists (fun arg -> arg = "--lifetime") Sys.argv in
 
@@ -91,6 +92,14 @@ let () =
         else program
       in
 
+      let program = if opt_prune
+        then
+          let opt = Transform.optimized_branch_prune program in
+          if not quiet then Printf.printf "\n** After speculative branch pruning:\n%s" (Disasm.disassemble opt);
+          opt
+        else program
+      in
+
       let program = if codemotion
         then
           let opt = Transform.hoist_assignment program in
@@ -106,7 +115,6 @@ let () =
           opt
         else program
       in
-
       List.iter (fun (name, instrs) ->
         Scope.check (Scope.infer instrs) (Array.map (fun _ -> None) instrs)) program;
 

--- a/transform.ml
+++ b/transform.ml
@@ -79,6 +79,149 @@ let branch_prune (prog : program) : program =
   let cleanup = remove_empty_jmp (remove_unreachable_code final) in
   ("main", cleanup) :: (deopt_label, main) :: rest
 
+let optimized_branch_prune prog =
+  let main = List.assoc "main" prog in
+  let rest = List.remove_assoc "main" prog in
+
+  (* Before starting to modify the program we add a label to every
+   * instruction to be able to find deopt points across optimizations.
+   * Also we add a comment as the first instruction because our later
+   * algorithm assumes that the entry point does not have a predecessor
+   * (eg. which would not work for: "loop: goto loop") *)
+  let main = Array.concat ([| Comment "__Entry" |] ::
+      List.mapi (fun pc instr ->
+        [| Label ("__pc_" ^ string_of_int pc); instr |])
+        (Array.to_list main)) in
+
+  let rec find_curr_pc_label instrs pc =
+    match[@warning "-4"] instrs.(pc) with
+    | Label l when String.length l > 5 && String.sub l 0 5 = "__pc_" -> l
+    | _ -> find_curr_pc_label instrs (pc-1)
+  in
+
+  let resolve_main = Instr.resolve main in
+  let scope_main = Scope.infer main in
+  let live_main = Analysis.live main in
+
+  (* Prune one Branch (e, l1, l2) at branch_pc.
+   * Guard_pc is a list of necessary guards. Note: guard_pcs can contain
+   * a pc which is equal to the branch_pc! *)
+  let prune_the_branch instrs branch_pc e l1 l2 guard_pcs deopt_version : instruction_stream =
+    let open Analysis in
+    let rec prune_the_branch pc acc =
+      if pc = Array.length instrs then
+        Array.of_list (List.rev acc)
+      else
+        (* Determine what to do at this pc *)
+        let remove_branch = pc = branch_pc in
+        let insert_osr = PcSet.mem pc guard_pcs in
+        let replace_branch_with_osr = insert_osr && remove_branch in
+
+        if remove_branch then
+          prune_the_branch (pc+1) (Goto l2 :: acc)
+        else if not insert_osr then
+          prune_the_branch (pc+1) (instrs.(pc) :: acc)
+        else begin
+          (* Create the guard *)
+          let deopt_label = if replace_branch_with_osr then l1 else find_curr_pc_label instrs pc in
+          let deopt_pc = resolve_main deopt_label in
+          let osr_capture = match scope_main.(deopt_pc) with
+            | Scope.Dead -> []
+            | Scope.Scope scope ->
+              List.map (function
+                | (Const_var, x) ->
+                  OsrConst (x, (Simple (Var x)))
+                | (Mut_var, x) ->
+                  if List.mem x (live_main deopt_pc) ||
+                     (* live is after the instruction but we need before *)
+                     VarSet.mem x (used_vars main.(deopt_pc))
+                  then OsrMut (x, x)
+                  else OsrMutUndef x)
+                (ModedVarSet.elements scope)
+          in
+          let osr_instr = Osr (e, deopt_version, deopt_label, osr_capture) in
+
+          if replace_branch_with_osr then
+            prune_the_branch (pc+1) (Goto l2 :: osr_instr :: acc)
+          else begin
+            assert (insert_osr);
+            match[@warning "-4"] instrs.(pc) with
+            | Label l ->
+              prune_the_branch (pc+1) (osr_instr :: Label l :: acc)
+            | _ ->
+              prune_the_branch (pc+1) (instrs.(pc) :: osr_instr :: acc)
+          end
+        end
+    in
+
+    prune_the_branch 0 []
+  in
+
+  let rec find_branch instrs pc =
+    if pc = Array.length instrs then None else
+    match[@warning "-4"] instrs.(pc) with
+    | Branch (e, l1, l2) ->
+      Some (pc, e, l1, l2)
+    | _ -> find_branch instrs (pc+1)
+  in
+
+  let find_optimal_guards_pos instrs pc used_vars =
+    let open Analysis in
+    let preds = Analysis.predecessors instrs in
+
+    (* Push the guard up in the cfg. As long as the guarded expression stays
+     * unchanged we can proceed. If we have multiple predecessors we push to
+     * all of them. (In unstructured cfgs we might push the guard to a branch
+     * which would not have to deopt).
+     * We push breadth first. If we end up in a position where all
+     * predecessors have been visited before we can drop this osr. The reason
+     * is that if we established the condition to be stable across a region
+     * spanning over all predecessors it must be the case that we also pushed
+     * the guard to some dominating positions. The only case where this can go
+     * wrong is if we are in a region without a dominator (ie. a loop without
+     * entry) but that is wrong code in the first place.
+     * This algo might might produce more guards than necessary. But we
+     * speculate it pays off since it can move loop invariant guards out of
+     * loops. *)
+    let rec find_optimal_guards_pos seen acc =
+      let can_move pc =
+        let affected = VarSet.inter (changed_vars instrs.(pc)) used_vars in
+        VarSet.is_empty affected in
+      let new_acc = PcSet.fold (fun pc set ->
+          let preds = PcSet.of_list preds.(pc) in
+          let new_preds = PcSet.diff preds seen in
+          let no_move = not (PcSet.for_all can_move new_preds) in
+          let seen pc = PcSet.mem pc seen in
+          let all_seen = PcSet.for_all seen preds in
+          if all_seen then set
+          else if no_move || PcSet.is_empty new_preds then PcSet.add pc set
+          else PcSet.union set new_preds
+        ) acc PcSet.empty
+      in
+      if PcSet.equal new_acc acc then acc
+      else find_optimal_guards_pos (PcSet.union seen acc) new_acc
+    in
+    find_optimal_guards_pos PcSet.empty (PcSet.singleton pc)
+  in
+
+  let deopt_version = "main_" ^ string_of_int (List.length prog) in
+  let rec prune_all_branches instrs =
+    match find_branch instrs 0 with
+    | None -> instrs
+    | Some (pc, e, l1, l2) ->
+      let used_vars = used_vars instrs.(pc) in
+      let guards = find_optimal_guards_pos instrs pc used_vars in
+      let opt_instrs = prune_the_branch instrs pc e l1 l2 guards deopt_version in
+      let opt_instrs = remove_unreachable_code opt_instrs in
+      prune_all_branches opt_instrs
+  in
+
+  let pruned = remove_empty_jmp (prune_all_branches main) in
+  (* remove entry comment *)
+  let pruned = Array.sub pruned 1 ((Array.length pruned)-1) in
+  ("main", pruned) :: (deopt_version, main) :: rest
+
+
 let move instrs from_pc to_pc =
   let (dir, to_pc) = if from_pc > to_pc then (-1, to_pc) else (1, to_pc-1) in
   let from = instrs.(from_pc) in


### PR DESCRIPTION
This is a revised implementation of branch pruning. Instead of just replacing `guard` by `osr` it will try to push the `osr` instruction up the call graph.

As long as the intermediate instructions do not change the value of the expression `exp` in `Branch (exp, l1, l2)` the guard can safely be performed earlier.

If while moving up the osr we encounter a pc where we have moved across every predecessor before, we can drop it. The assumption is that at least one of the predecessors must lead to a dominating pc
and that's where the final deopt will be placed. The only case where this goes wrong is when the entry instruction does not dominate us (ie. "loop: goto loop"). To rule out this case we add a comment
instruction as the first instruction (which is guaranteed to dominate all others).

Btw. this optimization introduces a new implementation technique where instead of using a pc_mapping we instrument the original code with a label at every instruction. This allows us to find back to the original position in unoptimized code.