### PR TITLE
Constant propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ test_examples: sourir
 	mkdir $(TEMPDIR)/examples
 	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet \
 	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --lifetime --cm --prune \
+	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --lifetime --prop --cm --prune \
 	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
 	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet \
 	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --lifetime --cm --prune \
+	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --lifetime --prop --cm --prune \
 	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
 	rm -rf $(TEMPDIR)
 

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -1,0 +1,66 @@
+open Instr
+
+let const_prop instrs =
+  let rec find_candidates instrs pc =
+    if pc = Array.length instrs then [] else
+    match[@warning "-4"] instrs.(pc) with
+    | Decl_const (x, Simple(Lit(n))) ->
+        (pc, x, n) :: find_candidates instrs (pc+1)
+    | _ -> find_candidates instrs (pc+1)
+  in
+
+  let convert x n instr =
+    let replace = Replace.var_in_exp x n in
+    match instr with
+    | Decl_const (y, e) ->
+      assert (x <> y);
+      Decl_const (y, replace e)
+    | Decl_mut (y, Some e) ->
+      assert (x <> y);
+      Decl_mut (y, Some (replace e))
+    | Assign (y, e) ->
+      assert (x <> y);
+      Assign (y, replace e)
+    | Branch (e, l1, l2) -> Branch (replace e, l1, l2)
+    | Print e -> Print (replace e)
+    | Osr (exp, l1, l2, env) ->
+      let env' = List.map (fun osr_def ->
+        match[@warning "-4"] osr_def with
+        | OsrConst (y, e) -> OsrConst (y, replace e)
+        | _ -> osr_def) env
+      in
+      Osr (replace exp, l1, l2, env')
+    | Drop y
+    | Decl_mut (y, None)
+    | Clear y
+    | Read y ->
+      assert (x <> y);
+      instr
+    | Label _ | Goto _ | Stop | Comment _ -> instr in
+
+  let rec to_convert instrs worklist x acc =
+    let open Analysis in
+    match worklist with
+    | [] -> acc
+    | pc :: rest ->
+      begin match[@warning "-4"] instrs.(pc) with
+      | Drop y when x = y -> acc
+      | instr ->
+        let succs = successors_at instrs pc in
+        if PcSet.mem pc acc then acc
+        else to_convert instrs (succs @ rest) x (PcSet.add pc acc)
+      end in
+
+  let work instrs =
+    let open Analysis in
+    let candidates = find_candidates instrs 0 in
+    let propagate instrs (pc, x, n) =
+      let succs = successors_at instrs pc in
+      let worklist = to_convert instrs succs x PcSet.empty in
+      let instrs = Array.copy instrs in
+      PcSet.iter (fun pc -> instrs.(pc) <- convert x (Lit(n)) instrs.(pc)) worklist;
+      instrs
+    in
+    List.fold_left propagate instrs candidates in
+
+  work instrs

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -44,10 +44,10 @@ let const_prop instrs =
     | [] -> acc
     | pc :: rest ->
       begin match[@warning "-4"] instrs.(pc) with
-      | Drop y when x = y -> acc
+      | Drop y when x = y -> to_convert instrs rest x acc
       | instr ->
         let succs = successors_at instrs pc in
-        if PcSet.mem pc acc then acc
+        if PcSet.mem pc acc then to_convert instrs rest x acc
         else to_convert instrs (succs @ rest) x (PcSet.add pc acc)
       end in
 

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -1,8 +1,7 @@
 open Instr
 
 (*
- * Constant propagation. Takes an instruction stream `instrs` and returns an
- * updated stream.
+ * Constant propagation. Takes a program `prog` and returns an updated stream.
  *
  * Finds all constant declarations of the form:
  *     const x = l
@@ -12,7 +11,10 @@ open Instr
  * is replaced by the literal `l`. Afterwards, the variable `x` is no longer
  * used, and the declaration can be removed by running `minimize_lifetimes`.
  *)
-let const_prop instrs =
+let const_prop prog =
+  let main = List.assoc "main" prog in
+  let rest = List.remove_assoc "main" prog in
+
   (* Finds the declarations that can be used for constant propagation.
      Returns a list of (pc, x, l) where `const x = l` is defined at pc `pc`. *)
   let rec find_candidates instrs pc acc =
@@ -75,7 +77,8 @@ let const_prop instrs =
              with our successors. *)
           let succs = successors_at instrs pc in
           find_targets instrs x (succs @ rest) (PcSet.add pc acc)
-      end in
+      end
+  in
 
   (* Perform constant propagation. *)
   let work instrs =
@@ -91,6 +94,8 @@ let const_prop instrs =
       PcSet.iter convert_at targets;
       instrs
     in
-    List.fold_left propagate instrs candidates in
+    List.fold_left propagate instrs candidates
+  in
 
-  work instrs
+  let result = work main in
+  ("main", result) :: rest

--- a/replace.ml
+++ b/replace.ml
@@ -1,0 +1,13 @@
+open Instr
+
+let var_in_simple_exp var (exp : simple_expression) (in_exp : simple_expression) : simple_expression =
+  match in_exp with
+  | Lit _ -> in_exp
+  | Var x -> if x = var then exp else in_exp
+
+let var_in_exp var (exp : simple_expression) (in_exp : expression) : expression =
+  let in_simple_expression = var_in_simple_exp var exp in
+  match in_exp with
+  | Simple se -> Simple (in_simple_expression se)
+  | Op (op, exps) ->
+    Op (op, List.map in_simple_expression exps)

--- a/sourir.ml
+++ b/sourir.ml
@@ -110,4 +110,5 @@ let () =
       List.iter (fun (name, instrs) ->
         Scope.check (Scope.infer instrs) (Array.map (fun _ -> None) instrs)) program;
 
+      Constantfold.const_prop (List.assoc "main" program);
       ignore (Eval.run_interactive IO.stdin_input program)

--- a/sourir.mllib
+++ b/sourir.mllib
@@ -9,3 +9,5 @@ Disasm
 Analysis
 Transform
 Rename
+Constantfold
+Replace

--- a/tests.ml
+++ b/tests.ml
@@ -611,6 +611,27 @@ let do_test_minimize_lifetime = function () ->
   assert_equal (Disasm.disassemble res) (Disasm.disassemble expected);
   ()
 
+let do_test_const_prop_driver () =
+  let test t e =
+    let main = List.assoc "main" in
+    let input, expected = main (parse_test t), main (parse_test e) in
+    let output = Constantfold.const_prop input in
+    if output <> expected then begin
+      Printf.printf "input: %s\noutput: %s\nexpected: %s\n%!"
+        (Disasm.disassemble_instr input)
+        (Disasm.disassemble_instr output)
+        (Disasm.disassemble_instr expected);
+      assert false
+    end in
+
+  test {input|
+    const x = 1
+    print x
+  |input} {expect|
+    const x = 1
+    print 1
+  |expect};
+  ()
 
 let suite =
   "suite">:::
@@ -705,6 +726,7 @@ let suite =
    "liveness">:: do_test_liveness;
    "codemotion">:: do_test_codemotion;
    "min_lifetimes">:: do_test_minimize_lifetime;
+   "constant_prop">:: do_test_const_prop_driver;
    ]
 ;;
 

--- a/tests.ml
+++ b/tests.ml
@@ -613,14 +613,13 @@ let do_test_minimize_lifetime = function () ->
 
 let do_test_const_prop_driver () =
   let test t e =
-    let main = List.assoc "main" in
-    let input, expected = main (parse_test t), main (parse_test e) in
+    let input, expected = (parse_test t), (parse_test e) in
     let output = Constantfold.const_prop input in
     if output <> expected then begin
       Printf.printf "input: %s\noutput: %s\nexpected: %s\n%!"
-        (Disasm.disassemble_instr input)
-        (Disasm.disassemble_instr output)
-        (Disasm.disassemble_instr expected);
+        (Disasm.disassemble input)
+        (Disasm.disassemble output)
+        (Disasm.disassemble expected);
       assert false
     end in
 


### PR DESCRIPTION
This PR implements constant propagation. @o- and I pair programmed the first commit, but later, I added some more tests and comments.

The strategy is pretty simple. Find all constant variable declarations of the form `const x = l` where `l` is a literal. Then, whenever `x` is in scope and used in an expression, rewrite the expression to use `l` instead of `x`. Afterwards, we can delete the declaration (and #62 does so).

The next step would be to implement constant folding (and this is why the code is in `constantfold.ml`). #73 tracks this, but I thought I'd break this up into separate PRs. Copy propagation is another thing we could implement, but I haven't really thought about it yet.

This optimization will become more powerful/useful once #61 is implemented. Then we can get some interesting examples.