### PR TITLE
refactoring: rename segment to version, remove special "active" label

### DIFF
--- a/constantfold.ml
+++ b/constantfold.ml
@@ -12,8 +12,7 @@ open Instr
  * used, and the declaration can be removed by running `minimize_lifetimes`.
  *)
 let const_prop prog =
-  let main = List.assoc "main" prog in
-  let rest = List.remove_assoc "main" prog in
+  let (name, instrs) = Instr.active_version prog in
 
   (* Finds the declarations that can be used for constant propagation.
      Returns a list of (pc, x, l) where `const x = l` is defined at pc `pc`. *)
@@ -97,5 +96,5 @@ let const_prop prog =
     List.fold_left propagate instrs candidates
   in
 
-  let result = work main in
-  ("main", result) :: rest
+  let result = work instrs in
+  Instr.replace_active_version prog (name, result)

--- a/doc/ir-semantics.text
+++ b/doc/ir-semantics.text
@@ -1,23 +1,21 @@
 # The formal language
 
 P ::= Function main  ↦ F, (Df ↦ F)*      program:            main function and other functions
-F ::= Segment active ↦ G, (Dg ↦ G)*      function body:      can contain multiple versions -- active segment and others
-G ::= start ↦ i, I                       a function version: instruction stream with dedicated start
+F ::= (lᵥ ↦ V)*                          function body:      can contain multiple versions
+V ::= start ↦ i, I                       a function version: instruction stream with dedicated start
 I ::= (l ↦ i)*                           instruction stream: labeled instructions
 
 Df ::= Function f(x, ...)          function declaration
-Dg ::= Segment  g                  segment declaration
 
 x        variables
 
 f  function name
-g  segment name
-l  labels
+l  branch label
+lᵥ version label
 
 Reserved Names:
 main      main function    (execution of program starts here)
-active    active segment   (function call executes this segment)
-start     start label      (execution of segment starts here)
+start     start label      (execution of function starts here)
 
 a  addresses
 
@@ -30,7 +28,7 @@ i ::=    instructions
 | goto l                        goto
 | print e                       print
 | return e                      return
-| osr(e, g, l, osr-map*)        osr : (can be used for osr-in and osr-out)
+| osr(e, f, lᵥ, l, osr-map*)    osr : (can be used for osr-in and osr-out)
 
 e ::=    (simple) expressions
 | lit                   literals
@@ -106,7 +104,7 @@ Update (partial) function, returns an H:
     when I(l) = (call x = f e*)
      and Df ∈ dom P
      and Df  = Function f y*
-     and I' := P(Df, Segment active)
+     and I' := hd P(Df)
      and E' := (y ↦ eval H E e)*
      and C' := (x, E, I, succ I l)
 
@@ -141,7 +139,7 @@ Update (partial) function, returns an H:
      and l' := if v = true  then l₁
                if v = false then l₂
 
-  step   osr(e, m^, l^, (osr-map, ...)) (P, I, T, H, E, l)
+  step   osr(e, f^, lᵥ^, l^, (osr-map, ...)) (P, I, T, H, E, l)
        = (I', T, H, E', l')
     when v := eval H E e
      and if v = false then
@@ -149,7 +147,9 @@ Update (partial) function, returns an H:
          l' := l
          E' := E
      and if v = true then
-         I' := P(m^)
+         Df ∈ dom P
+         Df  = Function f^ _
+         I' := P(Df, lᵥ^)
          l' := l^
          E' := (osr-env H E osr-map, ...)
 
@@ -163,7 +163,7 @@ declares i =
 requires i =
   | mut x = e
   | const x = e
-  | osr (e, v, l, (x = ee)*)
+  | osr (e, f, lᵥ, l, (x = ee)*)
                     -> vars(e) ∪ vars(ee)*
   | x <- e          -> x :: vars(e)
   | branch x _
@@ -212,7 +212,7 @@ generic requires/declares handling.
 
               A(v', l') = x*
   -------------------------------------
-  A, P ⊨d osr(e, v', l', (x = ee*)) : S
+  A, P ⊨d osr(e, f, lᵥ', l', (x = ee*)) : S
 
   ---------------
   A, P ⊨d stop : ∅

--- a/eval.ml
+++ b/eval.ml
@@ -238,7 +238,7 @@ let start program input pc : configuration = {
   status = Running;
   deopt = None;
   program = program;
-  instrs = List.assoc "main" program;
+  instrs = snd (Instr.active_version program);
   pc;
 }
 

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -1,4 +1,4 @@
-segment main
+version active
  # Based on a whiteboard example that also involves branch pruning
  # AFTER
  const zero = 0
@@ -9,7 +9,7 @@ segment main
  mut x = 30
  mut z = 0
  read z
- osr (z == zero) main_1 l1 [const one = one, const two = two, mut w1 = w1, mut w2 = w2, mut x = x, mut z = z, const zero = zero]
+ osr (z == zero) old l1 [const one = one, const two = two, mut w1 = w1, mut w2 = w2, mut x = x, mut z = z, const zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)
@@ -20,7 +20,7 @@ segment main
  print x
  stop
 
-segment main_1
+version old
  # Based on a whiteboard example that also involves branch pruning
  # BEFORE
  const zero = 0

--- a/instr.ml
+++ b/instr.ml
@@ -254,8 +254,14 @@ let used_vars = function
 
 type 'a dict = (string * 'a) list
 
-type segment = instruction_stream
-type program = segment dict
+type version = label * instruction_stream
+type program = version list
+
+let active_version (prog : program) : version =
+  (List.hd prog)
+
+let replace_active_version (prog : program) (repl : version) =
+  repl :: (List.tl prog)
 
 module Value = struct
   let int n : value = Lit (Int n)

--- a/lexer.mll
+++ b/lexer.mll
@@ -14,7 +14,7 @@ let keyword_table = [
   "read", READ;
   "drop", DROP;
   "clear", CLEAR;
-  "segment", SEGMENT;
+  "version", VERSION;
 ]
 
 let id_or_keyword id =

--- a/parser.messages
+++ b/parser.messages
@@ -1,14 +1,14 @@
-program: SEGMENT TRIPLE_DOT 
+program: VERSION TRIPLE_DOT 
 ##
 ## Ends in an error in state: 5.
 ##
-## segment -> SEGMENT . variable NEWLINE optional_newlines list(instruction_line) [ SEGMENT EOF ]
+## version -> VERSION . variable NEWLINE optional_newlines list(instruction_line) [ VERSION EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## SEGMENT 
+## VERSION 
 ##
 
-Missing segment identifier
+Missing version identifier
 
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
@@ -149,7 +149,7 @@ program: OSR NIL IDENTIFIER IDENTIFIER TRIPLE_DOT
 ##
 
 Parsing the specification of the new environment of an osr instruction
-failed. After "osr <exp> <segment> <label>" we expect a square bracket enclosed,
+failed. After "osr <exp> <version> <label>" we expect a square bracket enclosed,
 comma separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
 "[const x = 3, mut y = x, mut a]"
@@ -165,7 +165,7 @@ program: OSR NIL IDENTIFIER IDENTIFIER LBRACKET TRIPLE_DOT
 ##
 
 Parsing the specification of the new environment of an osr instruction
-failed. After "osr <exp> <segment> <label> [" we expect a comma
+failed. After "osr <exp> <version> <label> [" we expect a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
 "[const x = 3, mut y = x, mut a]"
@@ -180,9 +180,9 @@ program: OSR NIL IDENTIFIER TRIPLE_DOT
 ## OSR expression label 
 ##
 
-Parsing an osr instruction, we parsed "osr <expr> <segment>",
+Parsing an osr instruction, we parsed "osr <expr> <version>",
 and are now expecting a label. The complete instruction
-syntax is "osr <expr> <segment> <label> [<new_env>]", where
+syntax is "osr <expr> <version> <label> [<new_env>]", where
 "<new_env>" is a specification of the new environment. It's a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
@@ -199,8 +199,8 @@ program: OSR NIL TRIPLE_DOT
 ##
 
 Parsing an osr instruction, we parsed "osr <expr>", and
-are now expecting a segment label, for example "foo". The complete instruction
-syntax is "osr <expr> <segment> <label> [<new_env>]", where
+are now expecting a version label, for example "foo". The complete instruction
+syntax is "osr <expr> <version> <label> [<new_env>]", where
 "<new_env>" is a specification of the new environment. It's a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
@@ -218,7 +218,7 @@ program: OSR TRIPLE_DOT
 
 Parsing an osr instruction, we parsed "osr", and are now
 expecting an expression, for example "(x + 1)". The complete instruction
-syntax is "osr <expr> <segment> <label> [<new_env>]", where
+syntax is "osr <expr> <version> <label> [<new_env>]", where
 "<new_env>" is a specification of the new environment. It's a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
@@ -437,7 +437,7 @@ program: STOP NEWLINE TRIPLE_DOT
 ##
 ## Ends in an error in state: 85.
 ##
-## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ STOP SEGMENT READ PRINT OSR MUT LBRACE IDENTIFIER GOTO EOF DROP CONST COMMENT CLEAR BRANCH ]
+## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ STOP VERSION READ PRINT OSR MUT LBRACE IDENTIFIER GOTO EOF DROP CONST COMMENT CLEAR BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction NEWLINE 
@@ -450,7 +450,7 @@ program: STOP TRIPLE_DOT
 ##
 ## Ends in an error in state: 84.
 ##
-## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ STOP SEGMENT READ PRINT OSR MUT LBRACE IDENTIFIER GOTO EOF DROP CONST COMMENT CLEAR BRANCH ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ STOP VERSION READ PRINT OSR MUT LBRACE IDENTIFIER GOTO EOF DROP CONST COMMENT CLEAR BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction 

--- a/parser.mly
+++ b/parser.mly
@@ -5,7 +5,7 @@
 %token DOUBLE_EQUAL NOT_EQUAL PLUS /* MINUS TIMES LT LTE GT GTE */
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
-%token CONST MUT BRANCH GOTO PRINT OSR STOP READ DROP CLEAR SEGMENT
+%token CONST MUT BRANCH GOTO PRINT OSR STOP READ DROP CLEAR VERSION
 %token<string> COMMENT
 %token NEWLINE
 %token EOF
@@ -34,14 +34,14 @@ program_code:
       (Array.of_list instructions,
        Array.of_list annotations))]
   }
-| s1=segment segs=list(segment)
-  { s1 :: segs }
+| s1=version vers=list(version)
+  { s1 :: vers }
 
-segment:
-| SEGMENT segment=variable NEWLINE optional_newlines prog=list(instruction_line)
+version:
+| VERSION name=variable NEWLINE optional_newlines prog=list(instruction_line)
   {
     let annotations, instructions = List.split prog in
-    (segment,
+    (name,
      (Array.of_list instructions,
       Array.of_list annotations))
   }

--- a/rename.ml
+++ b/rename.ml
@@ -1,5 +1,6 @@
 open Instr
 
+(* TODO unify those 3 functions *)
 let fresh_var instrs var =
   let cand i = var ^ "_" ^ (string_of_int i) in
   let is_fresh cand_var instr =
@@ -18,6 +19,15 @@ let fresh_label instrs label =
   let rec find i =
     let cand_lab = cand i in
     if Array.for_all (is_fresh cand_lab) instrs
+    then cand_lab else find (i+1) in
+  find 1
+
+let fresh_version_label (prog:program) label =
+  let cand i = label ^ "_" ^ (string_of_int i) in
+  let existing = fst (List.split prog) in
+  let rec find i =
+    let cand_lab = cand i in
+    if not (List.mem cand_lab existing)
     then cand_lab else find (i+1) in
   find 1
 
@@ -73,7 +83,7 @@ let uses_in_instruction old_name new_name instr : instruction =
     assert (VarSet.is_empty (used_vars instr));
     instr
 
-let freshen_assign (instrs : segment) (def : pc) =
+let freshen_assign (instrs : instruction_stream) (def : pc) =
   let uses = Analysis.PcSet.elements (Analysis.used instrs def) in
   let instr = instrs.(def) in
   match[@warning "-4"] instr with

--- a/scope.ml
+++ b/scope.ml
@@ -25,8 +25,8 @@ type inferred_scope =
   | Dead
   | Scope of ModedVarSet.t
 
-type stream_annotation = scope_annotation option array
-type annotated_program = (instruction_stream * stream_annotation) Instr.dict
+type annotations = scope_annotation option array
+type annotated_program = (instruction_stream * annotations) Instr.dict
 
 let drop_annots : annotated_program -> program =
   List.map (fun (name, (instrs, annot)) -> (name, instrs))
@@ -166,3 +166,7 @@ let explain_incompatible_scope outchan s1 s2 pc =
   print_only buf "former" (ModedVarSet.diff s1.info s2.info) "latter";
   print_only buf "latter" (ModedVarSet.diff s2.info s1.info) "former";
   Buffer.output_buffer outchan buf
+
+let active_version (prog : annotated_program) : (label * instruction_stream * annotations) =
+  let (name, stream) = (List.hd prog) in
+  (name, fst stream, snd stream)

--- a/sourir.ml
+++ b/sourir.ml
@@ -76,7 +76,7 @@ let () =
         end;
         exit 1
       | Scope.IncompatibleScope (scope1, scope2, pc) ->
-        Disasm.pretty_print_segment stderr (name, instrs);
+        Disasm.pretty_print_version stderr (name, instrs);
         Scope.explain_incompatible_scope stderr scope1 scope2 pc;
         flush stderr;
         exit 1
@@ -87,7 +87,7 @@ let () =
       let program = if prune
         then
           let opt = Transform.branch_prune program in
-          if not quiet then Printf.printf "\n** After speculative branch pruning:\n%s" (Disasm.disassemble opt);
+          if not quiet then Printf.printf "\n** After speculative branch pruning:\n%s" (Disasm.disassemble_s opt);
           opt
         else program
       in
@@ -95,7 +95,7 @@ let () =
       let program = if codemotion
         then
           let opt = Transform.hoist_assignment program in
-          if not quiet then Printf.printf "\n** After trying to hoist one assignment:\n%s" (Disasm.disassemble opt);
+          if not quiet then Printf.printf "\n** After trying to hoist one assignment:\n%s" (Disasm.disassemble_s opt);
           opt
         else program
       in
@@ -103,7 +103,7 @@ let () =
       let program = if constprop
         then
           let opt = Constantfold.const_prop program in
-          if not quiet then Printf.printf "\n** After constant propagation:\n%s" (Disasm.disassemble opt);
+          if not quiet then Printf.printf "\n** After constant propagation:\n%s" (Disasm.disassemble_s opt);
           opt
         else program
       in
@@ -111,7 +111,7 @@ let () =
       let program = if lifetime
         then
           let opt = Transform.minimize_lifetimes program in
-          if not quiet then Printf.printf "\n** After minimizing lifetimes:\n%s" (Disasm.disassemble opt);
+          if not quiet then Printf.printf "\n** After minimizing lifetimes:\n%s" (Disasm.disassemble_s opt);
           opt
         else program
       in


### PR DESCRIPTION
This is a refactoring in preparation for the introduction of functions.
1. Fix a bug in the formalism for osr (missing function label)
2. Rename Segment to Version
3. Remove the special "active" segment. Now the active version is just
   the first version in the list. This allows us to change and add
   versions without having to rename all of them. Also the definition
   of active version is now behind the Instr.active_version api and
   should now be easier to change in the future.
4. Make the disassembler api more uniform