### PR TITLE
function references as values and indirect calls

### DIFF
--- a/analysis.ml
+++ b/analysis.ml
@@ -12,7 +12,7 @@ let successors_at (instrs : instruction_stream) pc : pc list =
   let all_succ =
     match instr with
     | Decl_const _ | Decl_mut _ | Assign _ | Drop _ | Clear _ | Read _
-    | Call _ | StaticCall _ | Label _ | Comment _ | Osr _ | Print _ ->
+    | Call _ | Label _ | Comment _ | Osr _ | Print _ ->
       let is_last = pc' = Array.length instrs in
       if is_last then [] else [pc']
     (* those are the instructions which manipulate controlflow:  *)

--- a/analysis.ml
+++ b/analysis.ml
@@ -12,7 +12,7 @@ let successors_at (instrs : instruction_stream) pc : pc list =
   let all_succ =
     match instr with
     | Decl_const _ | Decl_mut _ | Assign _ | Drop _ | Clear _ | Read _
-    | Call _ | Label _ | Comment _ | Osr _ | Print _ ->
+    | Call _ | StaticCall _ | Label _ | Comment _ | Osr _ | Print _ ->
       let is_last = pc' = Array.length instrs in
       if is_last then [] else [pc']
     (* those are the instructions which manipulate controlflow:  *)

--- a/check.ml
+++ b/check.ml
@@ -91,7 +91,7 @@ let well_formed prog =
       let check_simple_expr = function
         | Var _
         | Lit (Nil | Bool _ | Int _) -> ()
-        | Lit (FunRef x) -> ignore (lookup_fun x) in
+        | Lit (Fun_ref x) -> ignore (lookup_fun x) in
       let check_expr = function
         | Simple e -> check_simple_expr e
         | Op (_op, xs) ->
@@ -133,7 +133,7 @@ let well_formed prog =
         (* if it's a static call check that the function exists and if the
          * actual arguments are compatible with the formals *)
         begin match[@warning "-4"] f with
-        | (Simple (Lit (FunRef f))) ->
+        | (Simple (Lit (Fun_ref f))) ->
           let func' = lookup_fun f in
           check_signature pc func' exs
         | _ -> ()

--- a/check.ml
+++ b/check.ml
@@ -103,8 +103,6 @@ let well_formed prog =
         | Osr_const (_, e) -> check_expr e
         | Osr_mut _ | Osr_mut_undef _ -> () in
       match instr with
-      | StaticCall (_x, _f, es) ->
-        List.iter check_arg es
       | Call (_x, f, es) ->
         (check_expr f;
          List.iter check_arg es)
@@ -138,12 +136,6 @@ let well_formed prog =
           check_signature pc func' exs
         | _ -> ()
         end;
-        check_fun_ref instr
-      | StaticCall (x, f, exs) ->
-        (* Check call-by-name args are mut *)
-        List.iter (check_static_arg pc) exs;
-        let func' = lookup_fun f in
-        check_signature pc func' exs;
         check_fun_ref instr
       | Osr (e, f, v, l, osr) ->
         (* function and version mentioned in the osr need to exist *)

--- a/check.ml
+++ b/check.ml
@@ -90,8 +90,8 @@ let well_formed prog =
     let check_fun_ref instr =
       let check_simple_expr = function
         | Var _
-        | Lit (Nil | Bool _ | Int _) -> ()
-        | Lit (Fun_ref x) -> ignore (lookup_fun x) in
+        | Constant (Nil | Bool _ | Int _) -> ()
+        | Constant (Fun_ref x) -> ignore (lookup_fun x) in
       let check_expr = function
         | Simple e -> check_simple_expr e
         | Op (_op, xs) ->
@@ -131,7 +131,7 @@ let well_formed prog =
         (* if it's a static call check that the function exists and if the
          * actual arguments are compatible with the formals *)
         begin match[@warning "-4"] f with
-        | (Simple (Lit (Fun_ref f))) ->
+        | (Simple (Constant (Fun_ref f))) ->
           let func' = lookup_fun f in
           check_signature pc func' exs
         | _ -> ()

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -28,9 +28,12 @@ let const_prop (func : afunction) : afunction =
     let replace = Replace.var_in_exp x l in
     let replace_arg = Replace.var_in_arg x l in
     match instr with
+    | StaticCall (y, f, es) ->
+      assert (x <> y);
+      StaticCall (y, f, List.map replace_arg es)
     | Call (y, f, es) ->
       assert (x <> y);
-      Call (y, f, List.map replace_arg es)
+      Call (y, replace f, List.map replace_arg es)
     | Stop e ->
       Stop (replace e)
     | Return e ->

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -18,7 +18,7 @@ let const_prop (func : afunction) : afunction =
   let rec find_candidates instrs pc acc =
     if pc = Array.length instrs then acc
     else match[@warning "-4"] instrs.(pc) with
-    | Decl_const (x, Simple(Lit(l))) ->
+    | Decl_const (x, Simple(Constant(l))) ->
         find_candidates instrs (pc+1) ((pc, x, l) :: acc)
     | _ -> find_candidates instrs (pc+1) acc
   in
@@ -96,7 +96,7 @@ let const_prop (func : afunction) : afunction =
       let succs = successors_at instrs pc in
       let targets = find_targets instrs x succs PcSet.empty in
       let instrs = Array.copy instrs in
-      let convert_at pc = instrs.(pc) <- convert x (Lit(l)) instrs.(pc) in
+      let convert_at pc = instrs.(pc) <- convert x (Constant(l)) instrs.(pc) in
       PcSet.iter convert_at targets;
       instrs
     in

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -28,9 +28,6 @@ let const_prop (func : afunction) : afunction =
     let replace = Replace.var_in_exp x l in
     let replace_arg = Replace.var_in_arg x l in
     match instr with
-    | StaticCall (y, f, es) ->
-      assert (x <> y);
-      StaticCall (y, f, List.map replace_arg es)
     | Call (y, f, es) ->
       assert (x <> y);
       Call (y, replace f, List.map replace_arg es)

--- a/disasm.ml
+++ b/disasm.ml
@@ -32,6 +32,12 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
     format_pc buf pc;
     begin match instr with
     | Call (var, f, args)              ->
+      pr buf " call %s = *"var;
+      dump_expr f;
+      pr buf " (";
+      dump_comma_separated dump_arg args;
+      pr buf ")"
+    | StaticCall (var, f, args)        ->
       pr buf " call %s = %s (" var f;
       dump_comma_separated dump_arg args;
       pr buf ")"

--- a/disasm.ml
+++ b/disasm.ml
@@ -31,14 +31,10 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
     in
     format_pc buf pc;
     begin match instr with
-    | Call (var, f, args)              ->
+    | Call (var, f, args)               ->
       pr buf " call %s = *"var;
       dump_expr f;
       pr buf " (";
-      dump_comma_separated dump_arg args;
-      pr buf ")"
-    | StaticCall (var, f, args)        ->
-      pr buf " call %s = %s (" var f;
       dump_comma_separated dump_arg args;
       pr buf ")"
     | Stop exp                        -> pr buf " stop "; dump_expr exp

--- a/disasm.ml
+++ b/disasm.ml
@@ -14,7 +14,7 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
     in
     let simple buf = function
       | Var v             -> pr buf "%s" v
-      | Lit lit           -> pr buf "%s" (string_of_literal lit)
+      | Constant c        -> pr buf "%s" (string_of_value c)
     in
     let dump_expr exp =
       match exp with

--- a/doc/ir-semantics.text
+++ b/doc/ir-semantics.text
@@ -5,7 +5,7 @@ F ::= (lᵥ ↦ V)*                          function body:      can contain mul
 V ::= start ↦ i, I                       a function version: instruction stream with dedicated start
 I ::= (l ↦ i)*                           instruction stream: labeled instructions
 
-Df ::= Function f(mod x, ...)          function declaration
+Df ::= Function f((mod x)*)          function declaration
 
 x        variables
 
@@ -25,7 +25,7 @@ a  addresses
 
 i ::=    instructions
 | const x = e                   constant variable
-| call x = f arg*               function call
+| call x = fun (arg*)           function call
 | mut x = e                     mutable variable
 | x <- e                        assignment
 | branch e l₁ l₂                conditional
@@ -38,9 +38,14 @@ arg ::=
 | e
 | &x
 
+fun ::=
+| *e
+| f
+
 e ::=    (simple) expressions
 | lit                   literals
 | x                     variables
+| &&f                   function reference
 | primop(x, ...)        primitive operation (pure)
 
 lit ::=  literals
@@ -93,21 +98,24 @@ Update (partial) function, returns an H:
 
 ## Evaluation of simple expressions:
 
-  eval H E x = (H,E)[x]
-  eval H E lit = lit
-  eval H E primop(v, ...) = 〚primop〛(v, ...)
+  eval P H E x = (H,E)[x]
+  eval P H E lit = lit
+  eval P H E primop(v, ...) = 〚primop〛(v, ...)
+  eval P H E &&f            = f
+     and Df ∈ dom P
+     and Df  = Function f (mod y)*
 
 ## Osr transformation of environment
 
-  osr-env H E (const x = e) = (x ↦ eval H E e)
-  osr-env H E (mut x)       = (x ↦ ⊥)
-  osr-env H E (mut x = y)   = (x ↦ a)
+  osr-env P H E (const x = e) = (x ↦ eval P H E e)
+  osr-env P H E (mut x)       = (x ↦ ⊥)
+  osr-env P H E (mut x = y)   = (x ↦ a)
     where a = E(y)
 
 ## Argument evaluation
 
-  eval-arg H E const  e =  val eval H E e
-  eval-arg H E mut   &x =  ref a
+  eval-arg P H E const  e =  val eval P H E e
+  eval-arg P H E mut   &x =  ref a
     where E ∋ (x ↦ ref a)
 
 ## Reduction relation '-->'
@@ -117,14 +125,23 @@ Update (partial) function, returns an H:
   (P, C*) : (I, T, H, E, l) --> (P, (C*, C')) : (I', T, H, E', start)
     when I(l) = (call x = f (arg*))
      and Df ∈ dom P
-     and Df  = Function f (mod y)*
+     and Df  = Function f ((mod y)*)
      and I' := hd P(Df)
-     and E' := (y ↦ eval-arg H E mod arg)*
+     and E' := (y ↦ eval-arg P H E mod arg)*
+     and C' := (x, E, I, succ I l)
+
+  (P, C*) : (I, T, H, E, l) --> (P, (C*, C')) : (I', T, H, E', start)
+    when I(l) = (call x = *ef (arg*))
+     and f  := eval P H E ef
+     and Df ∈ dom P
+     and Df  = Function f ((mod y)*)
+     and I' := hd P(Df)
+     and E' := (y ↦ eval-arg P H E mod arg)*
      and C' := (x, E, I, succ I l)
 
   (P, (C*, C')) : (I, T, H, E, l) --> (P, C*) : (I', T, H, E'', l')
     when I(l) = (return e)
-     and v   := eval H E e
+     and v   := eval P H E e
      and C'   = (x', E', I', l')
      and E'' := E'[x' ↦ v]
 
@@ -132,30 +149,30 @@ Update (partial) function, returns an H:
 
   step   (const x = e) (P, I, T, H, E, l)
        = (I, T, H, E[x ↦ v], succ I l)
-    when v := eval H E e
+    when v := eval P H E e
 
   step   (mut x = e) (P, I, T, H, E, l)
        = (I, T, H[a ↦ v], E[x ↦ a], succ I l)
-    when v := eval H E e
+    when v := eval P H E e
      and a - fresh
 
   step   (x ← e) (P, I, T, H, E, l)
        = (I, T, (H,E)[x ← v], E, succ I l)
-    when v := eval H E e
+    when v := eval P H E e
 
   step   (print e) (P, I, T, H, E, l)
        = (I, (T, v), H, E, succ I l)
-    when v := eval H E e
+    when v := eval P H E e
 
   step   (branch e l₁ l₂) (P, I, T, H, E, l)
        = (I, T, H, E, l')
-    when v  := eval H E e
+    when v  := eval P H E e
      and l' := if v = true  then l₁
                if v = false then l₂
 
   step   osr(e, f^, lᵥ^, l^, (osr-map, ...)) (P, I, T, H, E, l)
        = (I', T, H, E', l')
-    when v := eval H E e
+    when v := eval P H E e
      and if v = false then
          I' := I
          l' := l
@@ -165,7 +182,7 @@ Update (partial) function, returns an H:
          Df  = Function f^ _
          I' := P(Df, lᵥ^)
          l' := l^
-         E' := (osr-env H E osr-map, ...)
+         E' := (osr-env P H E osr-map, ...)
 
 # Scopes
 

--- a/eval.ml
+++ b/eval.ml
@@ -27,12 +27,12 @@ type configuration = {
   continuation : continuation list;
 }
 
-type value_type = Nil | Bool | Int | FunRef
+type value_type = Nil | Bool | Int | Fun_ref
 let value_type : value -> value_type = function
   | Nil -> Nil
   | Bool _ -> Bool
   | Int _ -> Int
-  | FunRef _ -> FunRef
+  | Fun_ref _ -> Fun_ref
 
 exception Unbound_variable of variable
 exception Undefined_variable of variable
@@ -93,12 +93,12 @@ let value_eq (v1 : value) (v2 : value) =
   | Bool _, _ | _, Bool _ -> false
   | Int n1, Int n2 -> n1 = n2
   | Int _, _ | _, Int _ -> false
-  | FunRef f1, FunRef f2 -> f1 = f2
+  | Fun_ref f1, Fun_ref f2 -> f1 = f2
 
 let value_plus (v1 : value) (v2 : value) =
   match v1, v2 with
   | Int n1, Int n2 -> n1 + n2
-  | (Int _ | Nil | Bool _ | FunRef _) as x1, x2 ->
+  | (Int _ | Nil | Bool _ | Fun_ref _) as x1, x2 ->
       let expected = (Int, Int) in
       let received = value_type x1, value_type x2 in
       raise (ProductType_error { expected; received })
@@ -108,7 +108,7 @@ let value_neq (v1 : value) (v2 : value) =
 
 let eval_simple prog heap env = function
   | Var x -> lookup heap env x
-  | Lit (FunRef f) -> FunRef (lookup_fun prog f)
+  | Lit (Fun_ref f) -> Fun_ref (lookup_fun prog f)
   | Lit (Int i) -> Int i
   | Lit (Bool b) -> Bool b
   | Lit Nil -> Nil
@@ -126,15 +126,15 @@ let rec eval prog heap env = function
 let get_bool (v : value) =
   match v with
   | Bool b -> b
-  | (Nil | Int _ | FunRef _) as other ->
+  | (Nil | Int _ | Fun_ref _) as other ->
      let expected, received = Bool, value_type other in
      raise (Type_error { expected; received })
 
 let get_fun (v : value) =
   match v with
-  | FunRef f -> f
+  | Fun_ref f -> f
   | (Nil | Int _ | Bool _) as other ->
-     let expected, received = FunRef, value_type other in
+     let expected, received = Fun_ref, value_type other in
      raise (Type_error { expected; received })
 
 exception InvalidArgument

--- a/eval.ml
+++ b/eval.ml
@@ -192,19 +192,6 @@ let reduce conf =
   in
 
   match instruction with
-  | StaticCall (x, f, args) ->
-    let func = Instr.lookup_fun conf.program f in
-    let version = Instr.active_version func in
-    let call_env = build_call_frame func.formals args in
-    let cont_pos = (conf.cur_fun, conf.cur_vers, pc') in
-    { conf with
-      env = call_env;
-      instrs = version.instrs;
-      pc = 0;
-      cur_fun = func.name;
-      cur_vers = version.label;
-      continuation = (x, conf.env, cont_pos) :: conf.continuation
-    }
   | Call (x, f, args) ->
     let func = get_fun(eval conf f) in
     if List.length func.formals <> List.length args then raise InvalidNumArgs;

--- a/examples/fun_explicit.sou
+++ b/examples/fun_explicit.sou
@@ -1,6 +1,6 @@
 function main ()
  const x = 1
- call y = foo ()
+ call y = &&foo ()
  print y
 
 function foo ()

--- a/examples/fun_explicit.sou
+++ b/examples/fun_explicit.sou
@@ -1,6 +1,6 @@
 function main ()
  const x = 1
- call y = &&foo ()
+ call y = 'foo ()
  print y
 
 function foo ()

--- a/examples/fun_implicit_main.sou
+++ b/examples/fun_implicit_main.sou
@@ -1,4 +1,4 @@
-call x = &&foo ()
+call x = 'foo ()
 print x
 
 function foo ()

--- a/examples/fun_implicit_main.sou
+++ b/examples/fun_implicit_main.sou
@@ -1,4 +1,4 @@
-call x = foo ()
+call x = &&foo ()
 print x
 
 function foo ()

--- a/examples/fun_mut_const.sou
+++ b/examples/fun_mut_const.sou
@@ -1,10 +1,10 @@
 mut x = 1
 const y = 2
 
-call c1 = take_const (x)
-call c2 = take_const (y)
+call c1 = &&take_const (x)
+call c2 = &&take_const (y)
 const s1 = (c1+c2)
-call c3 = take_mut (&x)
+call c3 = &&take_mut (&x)
 
 print (s1+x)
 

--- a/examples/fun_mut_const.sou
+++ b/examples/fun_mut_const.sou
@@ -1,10 +1,10 @@
 mut x = 1
 const y = 2
 
-call c1 = &&take_const (x)
-call c2 = &&take_const (y)
+call c1 = 'take_const (x)
+call c2 = 'take_const (y)
 const s1 = (c1+c2)
-call c3 = &&take_mut (&x)
+call c3 = 'take_mut (&x)
 
 print (s1+x)
 

--- a/examples/fun_refs.sou
+++ b/examples/fun_refs.sou
@@ -1,5 +1,5 @@
-const afunref = &&foo
-call res = afunref (&&bar)
+const afunref = 'foo
+call res = afunref ('bar)
 print res
 
 function foo (const a)

--- a/examples/fun_refs.sou
+++ b/examples/fun_refs.sou
@@ -1,0 +1,10 @@
+const afunref = &&foo
+call res = *afunref (&&bar)
+print res
+
+function foo (const a)
+  call res = *a (2)
+  return res
+
+function bar (const x)
+  return (40+x)

--- a/examples/fun_refs.sou
+++ b/examples/fun_refs.sou
@@ -1,9 +1,9 @@
 const afunref = &&foo
-call res = *afunref (&&bar)
+call res = afunref (&&bar)
 print res
 
 function foo (const a)
-  call res = *a (2)
+  call res = a (2)
   return res
 
 function bar (const x)

--- a/instr.ml
+++ b/instr.ml
@@ -104,7 +104,7 @@ and literal =
   | Nil
   | Bool of bool
   | Int of int
-  | FunRef of string
+  | Fun_ref of string
 and primop =
   | Eq
   | Neq
@@ -143,7 +143,7 @@ type value =
   | Nil
   | Bool of bool
   | Int of int
-  | FunRef of afunction
+  | Fun_ref of afunction
 
 type heap_value =
   | Undefined
@@ -159,20 +159,20 @@ let string_of_literal : literal -> string = function
   | Nil -> "nil"
   | Bool b -> string_of_bool b
   | Int n -> string_of_int n
-  | FunRef f -> "&"^f
+  | Fun_ref f -> "&&"^f
 
 let string_of_value : value -> string = function
   | Nil -> "nil"
   | Bool b -> string_of_bool b
   | Int n -> string_of_int n
-  | FunRef f -> "&" ^ f.name
+  | Fun_ref f -> "&&" ^ f.name
 
 let literal_of_string : string -> literal = function
   | "nil" -> Nil
   | "true" -> Bool true
   | "false" -> Bool false
   | n when String.sub n 0 1 = "&" ->
-    FunRef (String.sub n 1 ((String.length n)-1))
+    Fun_ref (String.sub n 1 ((String.length n)-1))
   | n ->
     try Int (int_of_string n) with _ ->
       Printf.kprintf invalid_arg "literal_of_string %S" n

--- a/instr.ml
+++ b/instr.ml
@@ -152,7 +152,7 @@ let string_of_value : value -> string = function
   | Nil -> "nil"
   | Bool b -> string_of_bool b
   | Int n -> string_of_int n
-  | Fun_ref f -> "&&" ^ f
+  | Fun_ref f -> "'" ^ f
 
 let value_of_string : string -> value = function
   | "nil" -> Nil

--- a/instr.ml
+++ b/instr.ml
@@ -73,7 +73,6 @@ type instruction_stream = instruction array
 and instruction =
   | Decl_const of variable * expression
   | Decl_mut of variable * (expression option)
-  | StaticCall of variable * variable * (argument list)
   | Call of variable * expression * (argument list)
   | Return of expression
   | Drop of variable
@@ -210,7 +209,6 @@ let arg_vars = function
 
 let declared_vars = function
   | Call (x, _, _)
-  | StaticCall (x, _, _)
   | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
   | Decl_mut (x, _) -> ModedVarSet.singleton (Mut_var, x)
   | (Assign _
@@ -229,9 +227,6 @@ let declared_vars = function
 (* Which variables need to be in scope
  * Producer: declared_vars *)
 let required_vars = function
-  | StaticCall (_x, _f, es) ->
-    let vs = List.map arg_vars es in
-    List.fold_left VarSet.union VarSet.empty vs
   | Call (_x, f, es) ->
     let s = expr_vars f in
     let vs = List.map arg_vars es in
@@ -257,7 +252,6 @@ let required_vars = function
 
 let defined_vars = function
   | Call (x, _, _)
-  | StaticCall (x, _, _)
   | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
   | Decl_mut (x, Some _)
   | Assign (x ,_)
@@ -278,7 +272,6 @@ let dropped_vars = function
   | Drop x -> VarSet.singleton x
   | Return _
   | Call _
-  | StaticCall _
   | Decl_const _
   | Decl_mut _
   | Assign _
@@ -296,7 +289,6 @@ let cleared_vars = function
   | Clear x -> VarSet.singleton x
   | Return _
   | Call _
-  | StaticCall _
   | Decl_const _
   | Decl_mut _
   | Assign _
@@ -317,9 +309,6 @@ let used_vars = function
     let v = expr_vars f in
     let vs = List.map arg_vars es in
     List.fold_left VarSet.union v vs
-  | StaticCall (_x, _f, es) ->
-    let vs = List.map arg_vars es in
-    List.fold_left VarSet.union VarSet.empty vs
   | Stop e
   | Return e -> expr_vars e
   | Decl_const (_x, e) -> expr_vars e

--- a/lexer.mll
+++ b/lexer.mll
@@ -68,5 +68,6 @@ rule token = parse
   | "=" { EQUAL }
   | "<-" { LEFTARROW }
   | "&" { AMPERSAND }
+  | "'" { SINGLE_QUOTE }
   | eof { EOF }
   | _ { lexing_error lexbuf }

--- a/lexer.mll
+++ b/lexer.mll
@@ -68,5 +68,6 @@ rule token = parse
   | "=" { EQUAL }
   | "<-" { LEFTARROW }
   | "&" { AMPERSAND }
+  | "*" { STAR }
   | eof { EOF }
   | _ { lexing_error lexbuf }

--- a/lexer.mll
+++ b/lexer.mll
@@ -68,6 +68,5 @@ rule token = parse
   | "=" { EQUAL }
   | "<-" { LEFTARROW }
   | "&" { AMPERSAND }
-  | "*" { STAR }
   | eof { EOF }
   | _ { lexing_error lexbuf }

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 115.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 114.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 113.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,7 +43,7 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 89.
 ##
 ## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
 ##
@@ -57,7 +57,7 @@ example "(x + 1)", is now expected to construct a constant declaration
 
 program: CONST IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 88.
 ##
 ## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
 ##
@@ -71,7 +71,7 @@ Parsing an instruction, we parsed "const <var>" so far; the equal sign
 
 program: CONST TRIPLE_DOT 
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 87.
 ##
 ## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
 ##
@@ -85,7 +85,7 @@ example "x", is now expected to construct a constant declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 83.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +99,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 118.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,7 +113,7 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 82.
 ##
 ## label -> IDENTIFIER . [ COLON ]
 ## variable -> IDENTIFIER . [ LEFTARROW ]
@@ -128,7 +128,7 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 
 program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 62.
 ##
 ## instruction -> OSR expression label label label . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
@@ -144,7 +144,7 @@ comma separated list of "const <variable> = <expression>" or
 
 program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 63.
 ##
 ## instruction -> OSR expression label label label LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
@@ -160,7 +160,7 @@ separated list of "const <variable> = <expression>" or
 
 program: OSR NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 60.
 ##
 ## instruction -> OSR expression label . label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
@@ -178,7 +178,7 @@ separated list of "const <variable> = <expression>" or
 
 program: OSR NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 55.
+## Ends in an error in state: 58.
 ##
 ## instruction -> OSR expression . label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
@@ -196,7 +196,7 @@ separated list of "const <variable> = <expression>" or
 
 program: OSR TRIPLE_DOT 
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 57.
 ##
 ## instruction -> OSR . expression label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
@@ -292,7 +292,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 80.
 ##
 ## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
 ##
@@ -306,7 +306,7 @@ construct a constant mutable instruction "mut <var> = <expr>".
 
 program: MUT IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 79.
 ##
 ## instruction -> MUT variable . [ NEWLINE ]
 ## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
@@ -321,7 +321,7 @@ instruction "mut <var> = <expr>".
 
 program: MUT TRIPLE_DOT 
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 78.
 ##
 ## instruction -> MUT . variable [ NEWLINE ]
 ## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
@@ -337,9 +337,9 @@ declaration
 
 program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 46.
 ##
-## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression infixop simple_expression 
@@ -350,9 +350,9 @@ a closing parenthesis ")" is now expected.
 
 program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
 ##
-## Ends in an error in state: 42.
+## Ends in an error in state: 45.
 ##
-## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression infixop 
@@ -364,9 +364,9 @@ Parsing an expression, we parsed "( <arg> <op>" so far; an argument
 
 program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 41.
 ##
-## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression 
@@ -380,7 +380,7 @@ program: PRINT LPAREN TRIPLE_DOT
 ##
 ## Ends in an error in state: 34.
 ##
-## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE IDENTIFIER COMMA ]
+## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN 
@@ -392,7 +392,7 @@ literal value) is now expected to construct an expression
 
 program: PRINT TRIPLE_DOT 
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 55.
 ##
 ## instruction -> PRINT . expression [ NEWLINE ]
 ##
@@ -407,7 +407,7 @@ to construct a print instruction
 
 program: READ TRIPLE_DOT 
 ##
-## Ends in an error in state: 50.
+## Ends in an error in state: 53.
 ##
 ## instruction -> READ . variable [ NEWLINE ]
 ##
@@ -423,7 +423,7 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 123.
 ##
 ## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##
@@ -436,12 +436,12 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 32.
+## Ends in an error in state: 122.
 ##
-## instruction -> STOP . expression [ NEWLINE ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##
 ## The known suffix of the stack is as follows:
-## STOP 
+## scope_annotation instruction 
 ##
 
 We parsed an instruction, and are now expecting a newline to complete

--- a/parser.mly
+++ b/parser.mly
@@ -179,6 +179,6 @@ infixop:
 
 lit:
   | NIL { (Nil : literal) }
-  | AMPERSAND AMPERSAND f=variable { (FunRef f : literal) }
+  | AMPERSAND AMPERSAND f=variable { (Fun_ref f : literal) }
   | b=BOOL { (Bool b : literal) }
   | n=INT { (Int n : literal) }

--- a/parser.mly
+++ b/parser.mly
@@ -2,7 +2,7 @@
 %token<bool> BOOL
 %token<int> INT
 %token<string> IDENTIFIER
-%token AMPERSAND STAR
+%token AMPERSAND
 %token DOUBLE_EQUAL NOT_EQUAL PLUS /* MINUS TIMES LT LTE GT GTE */
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
@@ -114,10 +114,8 @@ osr_def:
     { Osr_mut (x, y) }
 
 instruction:
-| CALL x=variable EQUAL STAR f=expression LPAREN args=separated_list(COMMA, argument) RPAREN
+| CALL x=variable EQUAL f=expression LPAREN args=separated_list(COMMA, argument) RPAREN
   { Call (x, f, args) }
-| CALL x=variable EQUAL f=variable LPAREN args=separated_list(COMMA, argument) RPAREN
-  { StaticCall (x, f, args) }
 | RETURN e=expression
   { Return e }
 | CONST x=variable EQUAL e=expression

--- a/parser.mly
+++ b/parser.mly
@@ -2,7 +2,7 @@
 %token<bool> BOOL
 %token<int> INT
 %token<string> IDENTIFIER
-%token AMPERSAND
+%token AMPERSAND SINGLE_QUOTE
 %token DOUBLE_EQUAL NOT_EQUAL PLUS /* MINUS TIMES LT LTE GT GTE */
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
@@ -177,6 +177,6 @@ infixop:
 
 lit:
   | NIL { (Nil : value) }
-  | AMPERSAND AMPERSAND f=variable { (Fun_ref f : value) }
+  | SINGLE_QUOTE f=variable { (Fun_ref f : value) }
   | b=BOOL { (Bool b : value) }
   | n=INT { (Int n : value) }

--- a/parser.mly
+++ b/parser.mly
@@ -149,7 +149,7 @@ instruction:
   { Comment s }
 
 simple_expression:
-  | lit=lit { Lit lit }
+  | v=lit { Constant v }
   | x=variable { Var x }
 
 argument:
@@ -176,7 +176,7 @@ infixop:
   (* | GTE { Gte } *)
 
 lit:
-  | NIL { (Nil : literal) }
-  | AMPERSAND AMPERSAND f=variable { (Fun_ref f : literal) }
-  | b=BOOL { (Bool b : literal) }
-  | n=INT { (Int n : literal) }
+  | NIL { (Nil : value) }
+  | AMPERSAND AMPERSAND f=variable { (Fun_ref f : value) }
+  | b=BOOL { (Bool b : value) }
+  | n=INT { (Int n : value) }

--- a/parser.mly
+++ b/parser.mly
@@ -2,7 +2,7 @@
 %token<bool> BOOL
 %token<int> INT
 %token<string> IDENTIFIER
-%token AMPERSAND
+%token AMPERSAND STAR
 %token DOUBLE_EQUAL NOT_EQUAL PLUS /* MINUS TIMES LT LTE GT GTE */
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
@@ -114,8 +114,10 @@ osr_def:
     { Osr_mut (x, y) }
 
 instruction:
-| CALL x=variable EQUAL f=variable LPAREN args=separated_list(COMMA, argument) RPAREN
+| CALL x=variable EQUAL STAR f=expression LPAREN args=separated_list(COMMA, argument) RPAREN
   { Call (x, f, args) }
+| CALL x=variable EQUAL f=variable LPAREN args=separated_list(COMMA, argument) RPAREN
+  { StaticCall (x, f, args) }
 | RETURN e=expression
   { Return e }
 | CONST x=variable EQUAL e=expression
@@ -177,5 +179,6 @@ infixop:
 
 lit:
   | NIL { (Nil : literal) }
+  | AMPERSAND AMPERSAND f=variable { (FunRef f : literal) }
   | b=BOOL { (Bool b : literal) }
   | n=INT { (Int n : literal) }

--- a/rename.ml
+++ b/rename.ml
@@ -33,7 +33,7 @@ let fresh_version_label (func : afunction) label =
 
 let in_simple_expression old_name new_name (exp:simple_expression) : simple_expression =
   match exp with
-  | Lit _ -> exp
+  | Constant _ -> exp
   | Var x -> if x = old_name then Var new_name else exp
 
 let in_expression old_name new_name exp : expression =

--- a/rename.ml
+++ b/rename.ml
@@ -64,9 +64,6 @@ let uses_in_instruction old_name new_name instr : instruction =
   | Call (x, f, exs) ->
     assert(x != old_name);   (* -> invalid scope *)
     Call (x, in_expression f, List.map in_arg exs)
-  | StaticCall (x, f, exs) ->
-    assert(x != old_name);   (* -> invalid scope *)
-    StaticCall (x, f, List.map in_arg exs)
   | Stop e ->
     Stop (in_expression e)
   | Return e ->

--- a/rename.ml
+++ b/rename.ml
@@ -63,7 +63,10 @@ let uses_in_instruction old_name new_name instr : instruction =
   match instr with
   | Call (x, f, exs) ->
     assert(x != old_name);   (* -> invalid scope *)
-    Call (x, f, List.map in_arg exs)
+    Call (x, in_expression f, List.map in_arg exs)
+  | StaticCall (x, f, exs) ->
+    assert(x != old_name);   (* -> invalid scope *)
+    StaticCall (x, f, List.map in_arg exs)
   | Stop e ->
     Stop (in_expression e)
   | Return e ->

--- a/replace.ml
+++ b/replace.ml
@@ -2,7 +2,7 @@ open Instr
 
 let var_in_simple_exp var (exp : simple_expression) (in_exp : simple_expression) : simple_expression =
   match in_exp with
-  | Lit _ -> in_exp
+  | Constant _ -> in_exp
   | Var x -> if x = var then exp else in_exp
 
 let var_in_exp var (exp : simple_expression) (in_exp : expression) : expression =

--- a/sourir.ml
+++ b/sourir.ml
@@ -170,6 +170,6 @@ let () =
       exit n
     | Result (Bool b) ->
       exit (if b then 1 else 0)
-    | Result Nil | Result FunRef _ ->
+    | Result Nil | Result Fun_ref _ ->
       exit 0
 

--- a/sourir.ml
+++ b/sourir.ml
@@ -166,10 +166,10 @@ let () =
     let open Eval in
     match conf.status with
     | Running -> assert(false)
-    | Result (Lit (Int n)) ->
+    | Result (Int n) ->
       exit n
-    | Result (Lit (Bool b)) ->
+    | Result (Bool b) ->
       exit (if b then 1 else 0)
-    | Result (Lit Nil) ->
+    | Result Nil | Result FunRef _ ->
       exit 0
 

--- a/tests.ml
+++ b/tests.ml
@@ -8,7 +8,7 @@ let trace_is li =
 let has_var x v =
   fun conf -> Eval.(lookup conf.heap conf.env x = v)
 let returns n =
-  fun conf -> Eval.(conf.status = Result (Lit (Int n)))
+  fun conf -> Eval.(conf.status = Result (Int n))
 
 let (&&&) p1 p2 conf = (p1 conf) && (p2 conf)
 

--- a/tests.ml
+++ b/tests.ml
@@ -1069,7 +1069,7 @@ let test_functions () =
   let test str n =
     run (parse str) no_input (returns (Int n)) () in
   let test_p str out =
-    run (parse str) no_input (trace_is [out]) () in
+    run (parse str) no_input (trace_is out) () in
   test "return 1\n" 1;
   test "return (1+1)\n" 2;
   test {pr|
@@ -1115,7 +1115,7 @@ let test_functions () =
       return 1
   |pr} 3;
   assert_raises
-    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (Arg_by_val (Simple (Lit (Int 22)))))))
+    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (Arg_by_val (Simple (Constant (Int 22)))))))
     (fun () ->
     test {pr|
        call x = &&bla (22)
@@ -1212,7 +1212,7 @@ let test_functions () =
      print y
     function bla (const y)
       return y
-  |pr} "&&bla";
+  |pr} [(Fun_ref "bla")];
   test {pr|
      mut x = &&bla
      call y = x (&&bla2)
@@ -1266,11 +1266,11 @@ let suite =
   "suite">:::
   ["mut">:: run test_mut no_input
      (has_var "x" (Value.int 2)
-      &&& (trace_is ["1"; "2"]));
+      &&& (trace_is Value.[int 1; int 2]));
    "decl_const">:: run test_decl_const no_input
      (has_var "x" (Value.int 1));
    "print">:: run test_print no_input
-     (trace_is ["1"; "2"]);
+     (trace_is Value.[int 1; int 2]);
    "jump">:: run test_jump no_input
      (has_var "x" (Value.bool true));
    "jump (oo)" >:: run test_overloading no_input
@@ -1288,7 +1288,7 @@ let suite =
    "loops">:: run (test_sum 5) no_input
      (has_var "sum" (Value.int 10));
    "read">:: run test_read_print (input [Value.bool false; Value.int 1])
-     (trace_is ["1"; "false"]);
+     (trace_is Value.[int 1; bool false]);
    "mut_undeclared">::
    (fun () -> assert_raises (Eval.Unbound_variable "b")
        (run_unchecked test_read_print_err

--- a/tests.ml
+++ b/tests.ml
@@ -1212,7 +1212,7 @@ let test_functions () =
      print y
     function bla (const y)
       return y
-  |pr} "&bla";
+  |pr} "&&bla";
   test {pr|
      mut x = &&bla
      call y = *x (&&bla2)
@@ -1233,7 +1233,7 @@ let test_functions () =
         return y
     |pr} 22);
   let open Eval in
-  assert_raises (Eval.Type_error {expected = Eval.FunRef; received = Eval.Int})
+  assert_raises (Eval.Type_error {expected = Eval.Fun_ref; received = Eval.Int})
     (fun () ->
      test {pr|
        mut x = 1

--- a/tests.ml
+++ b/tests.ml
@@ -1073,7 +1073,7 @@ let test_functions () =
   test "return 1\n" 1;
   test "return (1+1)\n" 2;
   test {pr|
-     call x = bla ()
+     call x = &&bla ()
      return x
     function bla ()
      return 1
@@ -1082,32 +1082,32 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.InvalidNumArgs 0))
     (fun () ->
     test {pr|
-       call x = bla (1)
+       call x = &&bla (1)
       function bla ()
     |pr} 1);
   assert_raises
     (Check.ErrorAt ("bla", "anon", Check.MissingReturn))
     (fun () ->
     test {pr|
-       call x = bla ()
+       call x = &&bla ()
        return x
       function bla ()
     |pr} 0);
   test {pr|
-     call x = bla ()
+     call x = &&bla ()
      return x
     function bla ()
       return 123
   |pr} 123;
   test {pr|
-     call x = bla (22)
+     call x = &&bla (22)
      return x
     function bla (const y)
       return y
   |pr} 22;
   test {pr|
-     call one = one ()
-     call three = pl (one, 2)
+     call one = &&one ()
+     call three = &&pl (one, 2)
      return three
     function pl (const y, const z)
       return (y+z)
@@ -1118,21 +1118,21 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (Arg_by_val (Simple (Lit (Int 22)))))))
     (fun () ->
     test {pr|
-       call x = bla (22)
+       call x = &&bla (22)
        return x
       function bla (mut y)
         return y
     |pr} 22);
   test {pr|
      mut a = 3
-     call x = bla (&a)
+     call x = &&bla (&a)
      return x
     function bla (mut y)
       return y
   |pr} 3;
   test {pr|
      mut a = 3
-     call x = bla (&a)
+     call x = &&bla (&a)
      return a
     function bla (mut y)
      y <- 4
@@ -1156,7 +1156,7 @@ let test_functions () =
     (Check.DuplicateParameter ("bla", "x"))
     (fun () ->
     test {pr|
-      call x = bla (1, 2)
+      call x = &&bla (1, 2)
       function bla (const x, const x)
        return false
     |pr} 0);
@@ -1165,13 +1165,13 @@ let test_functions () =
     (fun () ->
     test {pr|
        mut x = 22
-       call y = bla (x)
+       call y = &&bla (x)
       function bla (mut y)
         return y
     |pr} 22);
   test {pr|
      mut x = 22
-     call y = bla (x)
+     call y = &&bla (x)
      return y
     function bla (const y)
       return y
@@ -1181,7 +1181,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = bla (x)
+       call y = &&bla (x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1190,7 +1190,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = bla (&x)
+       call y = &&bla (&x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1198,7 +1198,7 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.FunctionDoesNotExist "x"))
     (fun () ->
     test {pr|
-       call y = x ()
+       call y = &&x ()
     |pr} 0);
   assert_raises
     (Check.ErrorAt ("main", "anon", Check.FunctionDoesNotExist "x"))
@@ -1208,17 +1208,17 @@ let test_functions () =
     |pr} 0);
   test_p {pr|
      mut x = &&bla
-     call y = *x (x)
+     call y = x (x)
      print y
     function bla (const y)
       return y
   |pr} "&&bla";
   test {pr|
      mut x = &&bla
-     call y = *x (&&bla2)
+     call y = x (&&bla2)
      return y
     function bla (const y)
-      call r = *y ()
+      call r = y ()
       return r
     function bla2 ()
       return 33
@@ -1228,7 +1228,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = *&&bla (&x)
+       call y = &&bla (&x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1237,7 +1237,7 @@ let test_functions () =
     (fun () ->
      test {pr|
        mut x = 1
-       call y = *x ()
+       call y = x ()
        return y
     |pr} 33);
   assert_raises
@@ -1246,7 +1246,7 @@ let test_functions () =
     test {pr|
        const x = 22
        const func = &&bla
-       call y = *func (&x)
+       call y = func (&x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1256,7 +1256,7 @@ let test_functions () =
     test {pr|
        const x = 22
        const func = &&bla
-       call y = *func (x)
+       call y = func (x)
       function bla (mut y)
         return y
     |pr} 22);

--- a/tests.ml
+++ b/tests.ml
@@ -1073,7 +1073,7 @@ let test_functions () =
   test "return 1\n" 1;
   test "return (1+1)\n" 2;
   test {pr|
-     call x = &&bla ()
+     call x = 'bla ()
      return x
     function bla ()
      return 1
@@ -1082,32 +1082,32 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.InvalidNumArgs 0))
     (fun () ->
     test {pr|
-       call x = &&bla (1)
+       call x = 'bla (1)
       function bla ()
     |pr} 1);
   assert_raises
     (Check.ErrorAt ("bla", "anon", Check.MissingReturn))
     (fun () ->
     test {pr|
-       call x = &&bla ()
+       call x = 'bla ()
        return x
       function bla ()
     |pr} 0);
   test {pr|
-     call x = &&bla ()
+     call x = 'bla ()
      return x
     function bla ()
       return 123
   |pr} 123;
   test {pr|
-     call x = &&bla (22)
+     call x = 'bla (22)
      return x
     function bla (const y)
       return y
   |pr} 22;
   test {pr|
-     call one = &&one ()
-     call three = &&pl (one, 2)
+     call one = 'one ()
+     call three = 'pl (one, 2)
      return three
     function pl (const y, const z)
       return (y+z)
@@ -1118,21 +1118,21 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (Arg_by_val (Simple (Constant (Int 22)))))))
     (fun () ->
     test {pr|
-       call x = &&bla (22)
+       call x = 'bla (22)
        return x
       function bla (mut y)
         return y
     |pr} 22);
   test {pr|
      mut a = 3
-     call x = &&bla (&a)
+     call x = 'bla (&a)
      return x
     function bla (mut y)
       return y
   |pr} 3;
   test {pr|
      mut a = 3
-     call x = &&bla (&a)
+     call x = 'bla (&a)
      return a
     function bla (mut y)
      y <- 4
@@ -1156,7 +1156,7 @@ let test_functions () =
     (Check.DuplicateParameter ("bla", "x"))
     (fun () ->
     test {pr|
-      call x = &&bla (1, 2)
+      call x = 'bla (1, 2)
       function bla (const x, const x)
        return false
     |pr} 0);
@@ -1165,13 +1165,13 @@ let test_functions () =
     (fun () ->
     test {pr|
        mut x = 22
-       call y = &&bla (x)
+       call y = 'bla (x)
       function bla (mut y)
         return y
     |pr} 22);
   test {pr|
      mut x = 22
-     call y = &&bla (x)
+     call y = 'bla (x)
      return y
     function bla (const y)
       return y
@@ -1181,7 +1181,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = &&bla (x)
+       call y = 'bla (x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1190,7 +1190,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = &&bla (&x)
+       call y = 'bla (&x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1198,24 +1198,24 @@ let test_functions () =
     (Check.ErrorAt ("main", "anon", Check.FunctionDoesNotExist "x"))
     (fun () ->
     test {pr|
-       call y = &&x ()
+       call y = 'x ()
     |pr} 0);
   assert_raises
     (Check.ErrorAt ("main", "anon", Check.FunctionDoesNotExist "x"))
     (fun () ->
     test {pr|
-       const x = &&x
+       const x = 'x
     |pr} 0);
   test_p {pr|
-     mut x = &&bla
+     mut x = 'bla
      call y = x (x)
      print y
     function bla (const y)
       return y
   |pr} [(Fun_ref "bla")];
   test {pr|
-     mut x = &&bla
-     call y = x (&&bla2)
+     mut x = 'bla
+     call y = x ('bla2)
      return y
     function bla (const y)
       call r = y ()
@@ -1228,7 +1228,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       call y = &&bla (&x)
+       call y = 'bla (&x)
       function bla (mut y)
         return y
     |pr} 22);
@@ -1245,7 +1245,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       const func = &&bla
+       const func = 'bla
        call y = func (&x)
       function bla (mut y)
         return y
@@ -1255,7 +1255,7 @@ let test_functions () =
     (fun () ->
     test {pr|
        const x = 22
-       const func = &&bla
+       const func = 'bla
        call y = func (x)
       function bla (mut y)
         return y


### PR DESCRIPTION
Based on #77 

Adds to the language:
```
call x = *e ()  expects f to evaluate to a function reference
call x = f ()   is a static call to the function called f
const f = &&n   assigns a function reference to the function called n to the variable f
```

Internally they are called Call and StaticCall

Notes:
* This PR departs from Value = Literal in the implementation. I find it a bit cleaner this way but I don't have a strong opinion in case you liked it the way it was before.
* The syntax to create a function reference (`&&f`) is not super nice. Better suggestions are welcome. `&f` does not work due to ambiguity with the static call-by-ref/call-by-value annotation.
* Maybe we want `call x = e ()` and `static call x = f ()` at the surface instead of `call x = *e ()` and `call x = f ()`?