### PR TITLE
drive-by fix some names

### DIFF
--- a/check.ml
+++ b/check.ml
@@ -45,7 +45,7 @@ let well_formed prog =
   (* Formals args shall not contain duplicate variables *)
   let check_formals name formals =
     let formals = List.map (fun f -> match f with
-        | ParamConst x -> x | ParamMut x -> x) formals in
+        | Const_val_param x -> x | Mut_ref_param x -> x) formals in
     let check seen var =
       if VarSet.mem var seen
       then raise (DuplicateParameter (name, var))
@@ -76,8 +76,8 @@ let well_formed prog =
         then raise (InvalidNumArgs pc);
         let check_arg (formal, actual) =
             match[@warning "-4"] formal, actual with
-            | ParamConst _, ValArg _ -> ()
-            | ParamMut _, RefArg x ->
+            | Const_val_param _, Arg_by_val _ -> ()
+            | Mut_ref_param _, Arg_by_ref x ->
                 begin match scope.(pc) with
                 | DeadScope -> ()
                 | Scope scope ->

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -50,7 +50,7 @@ let const_prop (func : afunction) : afunction =
       (* Replace all expressions in the osr environment. *)
       let env' = List.map (fun osr_def ->
         match[@warning "-4"] osr_def with
-        | OsrConst (y, e) -> OsrConst (y, replace e)
+        | Osr_const (y, e) -> Osr_const (y, replace e)
         | _ -> osr_def) env
       in
       Osr (replace exp, f, v, l, env')

--- a/disasm.ml
+++ b/disasm.ml
@@ -26,8 +26,8 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
     in
     let dump_arg arg =
       match arg with
-      | ValArg e          -> dump_expr e
-      | RefArg x          -> pr buf "&%s" x
+      | Arg_by_val e      -> dump_expr e
+      | Arg_by_ref x      -> pr buf "&%s" x
     in
     format_pc buf pc;
     begin match instr with
@@ -53,9 +53,9 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
       dump_expr exp;
       pr buf " %s %s %s [" f v l;
       let dump_var = function
-        | OsrConst (x, e) -> pr buf "const %s = " x; dump_expr e;
-        | OsrMut (x, y) -> pr buf "mut %s = %s" x y;
-        | OsrMutUndef x -> pr buf "mut %s" x
+        | Osr_const (x, e) -> pr buf "const %s = " x; dump_expr e;
+        | Osr_mut (x, y)   -> pr buf "mut %s = %s" x y;
+        | Osr_mut_undef x  -> pr buf "mut %s" x
       in
       dump_comma_separated dump_var vars;
       pr buf "]"
@@ -69,8 +69,8 @@ let disassemble buf (prog : Instr.program) =
   (* TODO: disassemble annotations *)
   List.iter (fun {name; formals; body} ->
       let formals = List.map (fun x -> match x with
-          | ParamMut x -> "mut "^x
-          | ParamConst x -> "const "^x) formals in
+          | Mut_ref_param x -> "mut "^x
+          | Const_val_param x -> "const "^x) formals in
       let formals = String.concat ", " formals in
       Printf.bprintf buf "function %s (%s)\n" name formals;
       List.iter (fun version ->

--- a/doc/ir-semantics.text
+++ b/doc/ir-semantics.text
@@ -60,7 +60,7 @@ osr-map ::=    osr mapping declaration
 
 # Natural operational semantics
 
-E ::= (x ↦ val v | x ↦ var a | x ↦ ⊥)*  lexical environment
+E ::= (x ↦ val v | x ↦ ref a | x ↦ ⊥)*  lexical environment
 H ::= (l ↦ v)                             mutable heap
 
 T ::= (lit)*                    output trace
@@ -85,11 +85,11 @@ pred I l =
 Lookup (partial) function, returns a v:
   (H,E)[x] :=
     v    if E ∋ (x ↦ val v)
-    H(a) if E ∋ (x ↦ var a)
+    H(a) if E ∋ (x ↦ ref a)
 
 Update (partial) function, returns an H:
   (H,E)[x ← v] :=
-    H[a ↦ v] if E ∋ (x ↦ var a)
+    H[a ↦ v] if E ∋ (x ↦ ref a)
 
 ## Evaluation of simple expressions:
 
@@ -107,8 +107,8 @@ Update (partial) function, returns an H:
 ## Argument evaluation
 
   eval-arg H E const  e =  val eval H E e
-  eval-arg H E mut   &x =  var a
-    where E ∋ (x ↦ var a)
+  eval-arg H E mut   &x =  ref a
+    where E ∋ (x ↦ ref a)
 
 ## Reduction relation '-->'
 

--- a/instr.ml
+++ b/instr.ml
@@ -47,12 +47,12 @@ and instruction =
   | Stop of expression
   | Comment of string
 and osr_def =
-  | OsrConst of variable * expression
-  | OsrMut of variable * variable
-  | OsrMutUndef of variable
+  | Osr_const of variable * expression
+  | Osr_mut of variable * variable
+  | Osr_mut_undef of variable
 and argument =
-  | ValArg of expression
-  | RefArg of variable
+  | Arg_by_val of expression
+  | Arg_by_ref of variable
 and expression =
   | Simple of simple_expression
   | Op of primop * simple_expression list
@@ -78,8 +78,8 @@ type heap_value =
 type address = Address.t
 
 type binding =
-  | Const of value
-  | Mut of address
+  | Val of value
+  | Ref of address
 
 let string_of_literal : literal -> string = function
   | Nil -> "nil"
@@ -151,8 +151,8 @@ let expr_vars = function
     |> List.fold_left VarSet.union VarSet.empty
 
 let arg_vars = function
-  | ValArg e -> expr_vars e
-  | RefArg x -> VarSet.singleton x
+  | Arg_by_val e -> expr_vars e
+  | Arg_by_ref x -> VarSet.singleton x
 
 let declared_vars = function
   | Call (x, _, _)
@@ -190,9 +190,9 @@ let required_vars = function
   | Print e -> expr_vars e
   | Osr (e, _, _, _, osr) ->
     let exps = List.map (function
-        | OsrConst (_, e) -> e
-        | OsrMut (_, x) -> Simple (Var x)
-        | OsrMutUndef _ -> Simple (Lit Nil)) osr in
+        | Osr_const (_, e) -> e
+        | Osr_mut (_, x) -> Simple (Var x)
+        | Osr_mut_undef _ -> Simple (Lit Nil)) osr in
     let exps_vars = List.map expr_vars exps in
     List.fold_left VarSet.union (expr_vars e) exps_vars
 
@@ -271,9 +271,9 @@ let used_vars = function
   | Read _ -> VarSet.empty
   | Osr (e, _, _, _, osr) ->
     let exps = List.map (function
-        | OsrConst (_, e) -> e
-        | OsrMut (_, x) -> Simple (Var x)
-        | OsrMutUndef _ -> Simple (Lit Nil)) osr in
+        | Osr_const (_, e) -> e
+        | Osr_mut (_, x) -> Simple (Var x)
+        | Osr_mut_undef _ -> Simple (Lit Nil)) osr in
     let exps_vars = List.map expr_vars exps in
     List.fold_left VarSet.union (expr_vars e) exps_vars
 
@@ -294,8 +294,8 @@ type inferred_scope =
 type annotations = scope_annotation option array
 
 type formal_parameter =
-  | ParamConst of variable
-  | ParamMut of variable
+  | Const_val_param of variable
+  | Mut_ref_param of variable
 
 type version = {
   label : label;

--- a/parser.mly
+++ b/parser.mly
@@ -58,9 +58,9 @@ program_code:
 
 formal_param:
 | CONST x=variable
-    { ParamConst x }
+    { Const_val_param x }
 | MUT x=variable
-    { ParamMut x }
+    { Mut_ref_param x }
 
 afunction:
 | FUNCTION name=variable LPAREN formals=separated_list(COMMA, formal_param) RPAREN NEWLINE optional_newlines prog=list(instruction_line)
@@ -107,11 +107,11 @@ scope:
 
 osr_def:
 | CONST x=variable EQUAL e=expression
-    { OsrConst (x, e) }
+    { Osr_const (x, e) }
 | MUT x=variable
-    { OsrMutUndef x }
+    { Osr_mut_undef x }
 | MUT x=variable EQUAL y=variable
-    { OsrMut (x, y) }
+    { Osr_mut (x, y) }
 
 instruction:
 | CALL x=variable EQUAL f=variable LPAREN args=separated_list(COMMA, argument) RPAREN
@@ -153,8 +153,8 @@ simple_expression:
   | x=variable { Var x }
 
 argument:
-  | AMPERSAND x=variable { RefArg x }
-  | e=expression { ValArg e }
+  | AMPERSAND x=variable { Arg_by_ref x }
+  | e=expression { Arg_by_val e }
 
 expression:
   | e = simple_expression { Simple e }

--- a/rename.ml
+++ b/rename.ml
@@ -46,15 +46,15 @@ let in_expression old_name new_name exp : expression =
 let in_arg old_name new_name exp : argument =
   let in_expression = in_expression old_name new_name in
   match exp with
-  | ValArg e -> ValArg (in_expression e)
-  | RefArg x -> if x = old_name then RefArg new_name else RefArg x
+  | Arg_by_val e -> Arg_by_val (in_expression e)
+  | Arg_by_ref x -> if x = old_name then Arg_by_ref new_name else Arg_by_ref x
 
 let in_osr old_name new_name osr : osr_def =
   let in_expression = in_expression old_name new_name in
   match osr with
-  | OsrConst (x, exp) -> OsrConst (x, in_expression exp)
-  | OsrMut (x, y) -> if y = old_name then OsrMut (x, new_name) else osr
-  | OsrMutUndef _ -> osr
+  | Osr_const (x, exp) -> Osr_const (x, in_expression exp)
+  | Osr_mut (x, y) -> if y = old_name then Osr_mut (x, new_name) else osr
+  | Osr_mut_undef _ -> osr
 
 let uses_in_instruction old_name new_name instr : instruction =
   let in_expression = in_expression old_name new_name in

--- a/replace.ml
+++ b/replace.ml
@@ -15,5 +15,5 @@ let var_in_exp var (exp : simple_expression) (in_exp : expression) : expression 
 let var_in_arg var (exp : simple_expression) (in_arg : argument) : argument =
   let replace = var_in_exp var exp in
   match in_arg with
-    | ValArg e -> ValArg (replace e)
-    | RefArg x as a -> assert (var <> x); a
+    | Arg_by_val e -> Arg_by_val (replace e)
+    | Arg_by_ref x as a -> assert (var <> x); a

--- a/scope.ml
+++ b/scope.ml
@@ -24,8 +24,8 @@ let infer func version : inferred_scope array =
   let open Analysis in
 
   let to_moded_var = function
-    | ParamConst x -> (Const_var, x)
-    | ParamMut x -> (Mut_var, x)
+    | Const_val_param x -> (Const_var, x)
+    | Mut_ref_param x -> (Mut_var, x)
   in
   let formals = ModedVarSet.of_list (List.map to_moded_var func.formals) in
   if (List.length func.formals) <> (List.length (VarSet.elements (ModedVarSet.untyped formals))) then

--- a/tests.ml
+++ b/tests.ml
@@ -1113,7 +1113,7 @@ let test_functions () =
       return 1
   |pr} 3;
   assert_raises
-    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (ValArg (Simple (Lit (Int 22)))))))
+    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (0, (Arg_by_val (Simple (Lit (Int 22)))))))
     (fun () ->
     test {pr|
        call x = bla (22)
@@ -1159,7 +1159,7 @@ let test_functions () =
        return false
     |pr} 0);
   assert_raises
-    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (ValArg (Simple (Var "x"))))))
+    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (Arg_by_val (Simple (Var "x"))))))
     (fun () ->
     test {pr|
        mut x = 22
@@ -1175,7 +1175,7 @@ let test_functions () =
       return y
   |pr} 22;
   assert_raises
-    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (ValArg (Simple (Var "x"))))))
+    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (Arg_by_val (Simple (Var "x"))))))
     (fun () ->
     test {pr|
        const x = 22
@@ -1184,7 +1184,7 @@ let test_functions () =
         return y
     |pr} 22);
   assert_raises
-    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (RefArg "x"))))
+    (Check.ErrorAt ("main", "anon", Check.InvalidArgument (1, (Arg_by_ref "x"))))
     (fun () ->
     test {pr|
        const x = 22

--- a/transform.ml
+++ b/transform.ml
@@ -60,12 +60,12 @@ let branch_prune (func : afunction) : afunction =
         | Branch (exp, l1, l2) ->
           let osr = List.map (function
               | (Const_var, x) ->
-                OsrConst (x, (Simple (Var x)))
+                Osr_const (x, (Simple (Var x)))
               | (Mut_var, x) ->
                 if List.mem x (live pc) then
-                  OsrMut (x, x)
+                  Osr_mut (x, x)
                 else
-                  OsrMutUndef x)
+                  Osr_mut_undef x)
               (ModedVarSet.elements scope)
           in
           branch_prune pc'


### PR DESCRIPTION
* bindings are either (x -> val v) or (x -> ref a)
* formal parameters either take a 'mutable reference' or a 'const value'
* actual arguments are passed by_value or by_name
* the (slight majority) convention for constructor names in our code is Camel_dash