### PR TITLE
[WIP] add named tuples

### DIFF
--- a/doc/ir-semantics.text
+++ b/doc/ir-semantics.text
@@ -28,11 +28,14 @@ i ::=    instructions
 | call x = e (arg*)             function call
 | mut x = e                     mutable variable
 | x <- e                        assignment
+| x.n <- e                      tuple update
 | branch e l₁ l₂                conditional
 | goto l                        goto
 | print e                       print
 | return e                      return
 | osr(e, f, lᵥ, l, osr-map*)    osr : (can be used for osr-in and osr-out)
+
+n - tuple index name
 
 arg ::=
 | e
@@ -41,6 +44,8 @@ arg ::=
 e ::=     expression
 | se                    simple expression
 | primop(se*)           primitive operation (pure)
+| <n:se*>               tuple ctr
+| se.n                  tuple access
 
 se ::=    simple expressions
 | lit                   literals
@@ -51,10 +56,12 @@ lit ::=  literals
 | nil
 | true | false
 | 0 | 1 | 2 | ...
+| "strings"
 
 v :=     values
 | lit                   literals
 | f                     function reference
+| <n:v*>                tuples
 
 (Note: heap adresses are not values)
 
@@ -107,6 +114,11 @@ Update (partial) function, returns an H:
   eval P H E se          = simple-eval P H E se
   eval P H E primop(se*) = 〚primop〛(v*)
     where v := simple-eval P H E se
+  eval P H E <n:se*>      = <n:v*>
+    where v := simple-eval P H E se
+  eval P H E se.n          = vₙ
+    where v := simple-eval P H E se
+      and v = <...,n:vₙ, ...>
 
 ## Osr transformation of environment
 
@@ -154,6 +166,13 @@ Update (partial) function, returns an H:
   step   (x ← e) (P, I, T, H, E, l)
        = (I, T, (H,E)[x ← v], E, succ I l)
     when v := eval P H E e
+
+  step   (x.n ← e) (P, I, T, H, E, l)
+       = (I, T, (H,E)[x ← v'], E, succ I l)
+    when vₐ := eval P H E e
+     and v   = (H,E)[x]
+     and v   = <..., n:vₙ, ...>
+     and v'  = <..., n:vₐ, ...>
 
   step   (print e) (P, I, T, H, E, l)
        = (I, (T, v), H, E, succ I l)

--- a/doc/ir-semantics.text
+++ b/doc/ir-semantics.text
@@ -38,11 +38,14 @@ arg ::=
 | e
 | &x
 
-e ::=    (simple) expressions
+e ::=     expression
+| se                    simple expression
+| primop(se*)           primitive operation (pure)
+
+se ::=    simple expressions
 | lit                   literals
 | x                     variables
-| 'f                    function reference
-| primop(x, ...)        primitive operation (pure)
+| 'f                    create function reference
 
 lit ::=  literals
 | nil
@@ -51,6 +54,7 @@ lit ::=  literals
 
 v :=     values
 | lit                   literals
+| f                     function reference
 
 (Note: heap adresses are not values)
 
@@ -62,7 +66,7 @@ osr-map ::=    osr mapping declaration
 # Natural operational semantics
 
 E ::= (x ↦ val v | x ↦ ref a | x ↦ ⊥)*  lexical environment
-H ::= (l ↦ v)                             mutable heap
+H ::= (l ↦ v)                           mutable heap
 
 T ::= (lit)*                    output trace
 
@@ -92,14 +96,17 @@ Update (partial) function, returns an H:
   (H,E)[x ← v] :=
     H[a ↦ v] if E ∋ (x ↦ ref a)
 
-## Evaluation of simple expressions:
+## Evaluation of (simple) expressions:
 
-  eval P H E x = (H,E)[x]
-  eval P H E lit = lit
-  eval P H E primop(v, ...) = 〚primop〛(v, ...)
-  eval P H E 'f             = f
+  simple-eval P H E x   = (H,E)[x]
+  simple-eval P H E lit = lit
+  simple-eval P H E 'f  = f
     where Df ∈ dom P
       and Df  = Function f (formal*)
+
+  eval P H E se          = simple-eval P H E se
+  eval P H E primop(se*) = 〚primop〛(v*)
+    where v := simple-eval P H E se
 
 ## Osr transformation of environment
 


### PR DESCRIPTION
Let's talk about how we add tuples. This PR is intended to start a discussion about the design. I volunteer to implement. But if anybody else wants to continue from here it can also be limited to just the changes to ir-semantics.text.

The current proposal is very lightweight. With this we could type-check const tuples but not mut. Also update gives no guarantees preserving types. This is kind of in line with the rest of the language since we don't have type annotations except for mut/const. (But it is debatable...)

Also I tried to keep eval non-recursive (though I am not sure anymore why we wanted that). You can create recursive tuples step-by-step:

```
const x3 = <a:3, b:nil>
const x2 = <a:2, b:x3>
const x1 = <a:1, b:x1>
```

Access works as you expect.

I also added strings. Here is an object system on top of it:

```
function lookup (mut obj, const selector)
    mut m = obj.vtable
  loop:
    branch (m.selector == selector)  done next
  next:
    m <- m.next
    goto loop
  done:
    return m.func

function invoke (mut obj, const selector, const args)
  call m = 'lookup (obj, selector)
  call r = m (obj, args)
  return r

function vec_length (mut this)
  return sq(this.x*this.x + this.y*this.y)

function vec_add (mut this, const args)
  const other = args.1
  call res = 'new_vec (this.x+other.x, this.y+other.y)
  return res

function new_vec (const x, const y)
  const vtable =
   <selector:"add", method:'vec_add, next=
    <selector:"lenght", method='vec_length, next=<>>>
  return <vtable:vtable, x:x, y:y>

function main ()
  call a = 'new_vec (1,2)
  call b = 'new_vec (2,1)
  call ab = 'invoke (&a, "add", <1:b>)
  call l = 'invoke (&ab, "length")
```

Also, we could remove nil from the language since we have the empty tuple `<>` now.