### PR TITLE
change osr syntax and instruction

### DIFF
--- a/check.ml
+++ b/check.ml
@@ -19,7 +19,6 @@ exception InvalidNumArgs of pc
 exception InvalidArgument of pc * argument
 exception MissingReturn
 
-
 module IdentifierSet = Set.Make(Identifier)
 
 let well_formed prog =
@@ -117,9 +116,9 @@ let well_formed prog =
       | Decl_mut (_, None)
       | Drop _ | Clear _ | Read _
       | Label _ | Goto _ | Comment _ -> ()
-      | Osr (e, _, _, _, osr) ->
-        check_expr e;
-        List.iter check_osr osr
+      | Osr {cond; map} ->
+        check_expr cond;
+        List.iter check_osr map
     in
 
     (* Check correctness of calls and osrs *)
@@ -137,11 +136,12 @@ let well_formed prog =
         | _ -> ()
         end;
         check_fun_ref instr
-      | Osr (e, f, v, l, osr) ->
-        (* function and version mentioned in the osr need to exist *)
-        let func = lookup_fun f in
-        let vers = lookup_version func v in
-        let _ = Instr.resolve vers.instrs l in
+      | Osr {target = {func; version; label}} ->
+        (* check if the function exists and if the actual arguments
+         * are compatible with the formals *)
+        let func = lookup_fun func in
+        let vers = lookup_version func version in
+        let _ = Instr.resolve vers.instrs label in
         check_fun_ref instr
       | _ -> check_fun_ref instr
     in

--- a/constantfold.ml
+++ b/constantfold.ml
@@ -46,14 +46,15 @@ let const_prop (func : afunction) : afunction =
       Assign (y, replace e)
     | Branch (e, l1, l2) -> Branch (replace e, l1, l2)
     | Print e -> Print (replace e)
-    | Osr (exp, f, v, l, env) ->
+    | Osr {cond; target; map} ->
       (* Replace all expressions in the osr environment. *)
-      let env' = List.map (fun osr_def ->
+      let map = List.map (fun osr_def ->
         match[@warning "-4"] osr_def with
         | Osr_const (y, e) -> Osr_const (y, replace e)
-        | _ -> osr_def) env
+        | _ -> osr_def) map
       in
-      Osr (replace exp, f, v, l, env')
+      let cond = replace cond in
+      Osr {cond; target; map}
     | Drop y
     | Decl_mut (y, None)
     | Clear y

--- a/disasm.ml
+++ b/disasm.ml
@@ -50,16 +50,16 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instruction_str
     | Goto label                      -> pr buf " goto %s" label
     | Print exp                       -> pr buf " print "; dump_expr exp
     | Read var                        -> pr buf " read %s" var
-    | Osr (exp, f, v, l, vars)        ->
+    | Osr {cond; target = {func; version; label}; map} ->
       pr buf " osr ";
-      dump_expr exp;
-      pr buf " %s %s %s [" f v l;
+      dump_expr cond;
+      pr buf " (%s, %s, %s) [" func version label;
       let dump_var = function
         | Osr_const (x, e) -> pr buf "const %s = " x; dump_expr e;
         | Osr_mut (x, y)   -> pr buf "mut %s = %s" x y;
         | Osr_mut_undef x  -> pr buf "mut %s" x
       in
-      dump_comma_separated dump_var vars;
+      dump_comma_separated dump_var map;
       pr buf "]"
     | Comment str                     -> pr buf " #%s" str
     end;

--- a/eval.ml
+++ b/eval.ml
@@ -280,31 +280,31 @@ let reduce conf =
       pc = pc';
     }
   | Print e ->
-     let v = eval conf e in
-     { conf with
-       trace = v :: conf.trace;
-       pc = pc';
-     }
-  | Osr (e, f, v, l, osr_def) ->
-     let b = get_bool (eval conf e) in
-     if not b then
-       { conf with
-         pc = pc';
-       }
-     else begin
-       let osr_env = build_osr_frame osr_def in
-       let osr_func = Instr.lookup_fun conf.program f in
-       let osr_version = Instr.get_version osr_func v in
-       let osr_instrs = osr_version.instrs in
-       { conf with
-         pc = resolve osr_instrs l;
-         env = osr_env;
-         instrs = osr_instrs;
-         cur_fun = osr_func.name;
-         cur_vers = osr_version.label;
-         deopt = Some l;
-       }
-     end
+    let v = eval conf e in
+    { conf with
+      trace = v :: conf.trace;
+      pc = pc';
+    }
+  | Osr {cond; target={func;version; label}; map} ->
+    let b = get_bool (eval conf cond) in
+    if not b then
+      { conf with
+        pc = pc';
+      }
+    else begin
+      let osr_env = build_osr_frame map in
+      let func = Instr.lookup_fun conf.program func in
+      let version = Instr.get_version func version in
+      let instrs = version.instrs in
+      { conf with
+        pc = resolve instrs label;
+        env = osr_env;
+        instrs = instrs;
+        cur_fun = func.name;
+        cur_vers = version.label;
+        deopt = Some label;
+      }
+    end
 
 let start program input pc : configuration = {
   input;

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -11,7 +11,7 @@ version active
  mut x = 30
  mut z = 0
  read z
- osr (z == zero) main old l1 [const one = one, const two = two, mut w1 = w1, mut w2 = w2, mut x = x, mut z = z, const zero = zero]
+ osr (z==zero) (main,old,l1) [const one = one, const two = two, mut w1 = w1, mut w2 = w2, mut x = x, mut z = z, const zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 113.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 112.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 111.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,7 +43,7 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 92.
 ##
 ## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
 ##
@@ -57,7 +57,7 @@ example "(x + 1)", is now expected to construct a constant declaration
 
 program: CONST IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 87.
+## Ends in an error in state: 91.
 ##
 ## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
 ##
@@ -71,7 +71,7 @@ Parsing an instruction, we parsed "const <var>" so far; the equal sign
 
 program: CONST TRIPLE_DOT 
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 90.
 ##
 ## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
 ##
@@ -85,7 +85,7 @@ example "x", is now expected to construct a constant declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 86.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +99,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 116.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,7 +113,7 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 85.
 ##
 ## label -> IDENTIFIER . [ COLON ]
 ## variable -> IDENTIFIER . [ LEFTARROW ]
@@ -126,52 +126,34 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 - if this is a label declaration, we expect a semicolon: "<label>:"
 - if this is an assignment, we expect a left arrow: "<var> <- <expression>"
 
-program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER TRIPLE_DOT 
+program: OSR NIL LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 65.
 ##
-## instruction -> OSR expression label label label . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR expression LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR expression label label label 
+## OSR expression LPAREN label COMMA label COMMA label RPAREN 
 ##
 
 Parsing the specification of the new environment of an osr instruction
-failed. After "osr <exp> <function> <version> <label>" we expect a square bracket enclosed,
+failed. After "osr <exp> (<function>, <version>, <label>)" we expect a square bracket enclosed,
 comma separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
 "[const x = 3, mut y = x, mut a]"
 
-program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER LBRACKET TRIPLE_DOT 
+program: OSR NIL LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 66.
 ##
-## instruction -> OSR expression label label label LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR expression LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR expression label label label LBRACKET 
+## OSR expression LPAREN label COMMA label COMMA label RPAREN LBRACKET 
 ##
 
 Parsing the specification of the new environment of an osr instruction
-failed. After "osr <exp> <function> <version> <label> [" we expect a comma
-separated list of "const <variable> = <expression>" or
-"mut <variable> = <expression>" or "mut x". For example:
-"[const x = 3, mut y = x, mut a]"
-
-program: OSR NIL IDENTIFIER TRIPLE_DOT 
-##
-## Ends in an error in state: 59.
-##
-## instruction -> OSR expression label . label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
-##
-## The known suffix of the stack is as follows:
-## OSR expression label 
-##
-
-Parsing an osr instruction, we parsed "osr <expr> <version>",
-and are now expecting a label. The complete instruction
-syntax is "osr <expr> <version> <label> [<new_env>]", where
-"<new_env>" is a specification of the new environment. It's a comma
+failed. After "osr <exp> (<function>, <version>, <label>) [" we expect a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
 "[const x = 3, mut y = x, mut a]"
@@ -180,15 +162,15 @@ program: OSR NIL TRIPLE_DOT
 ##
 ## Ends in an error in state: 57.
 ##
-## instruction -> OSR expression . label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR expression . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR expression 
 ##
 
-Parsing an osr instruction, we parsed "osr <expr>", and
-are now expecting a version label, for example "foo". The complete instruction
-syntax is "osr <expr> <version> <label> [<new_env>]", where
+Parsing an osr instruction, we parsed "osr <expr> ",
+and are now expecting a (function, version, label) tripple.
+The complete instruction syntax is "osr <expr> (<function>, <version>, <label>) [<new_env>]", where
 "<new_env>" is a specification of the new environment. It's a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
@@ -198,15 +180,15 @@ program: OSR TRIPLE_DOT
 ##
 ## Ends in an error in state: 56.
 ##
-## instruction -> OSR . expression label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR . expression LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR 
 ##
 
 Parsing an osr instruction, we parsed "osr", and are now
-expecting an expression, for example "(x + 1)". The complete instruction
-syntax is "osr <expr> <version> <label> [<new_env>]", where
+expecting an expression, for example "(x + 1)".
+The complete instruction syntax is "osr <expr> (<function>, <version>, <label>) [<new_env>]", where
 "<new_env>" is a specification of the new environment. It's a comma
 separated list of "const <variable> = <expression>" or
 "mut <variable> = <expression>" or "mut x". For example:
@@ -292,7 +274,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 83.
 ##
 ## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
 ##
@@ -306,7 +288,7 @@ construct a constant mutable instruction "mut <var> = <expr>".
 
 program: MUT IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 82.
 ##
 ## instruction -> MUT variable . [ NEWLINE ]
 ## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
@@ -321,7 +303,7 @@ instruction "mut <var> = <expr>".
 
 program: MUT TRIPLE_DOT 
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 81.
 ##
 ## instruction -> MUT . variable [ NEWLINE ]
 ## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
@@ -423,7 +405,7 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 121.
 ##
 ## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##
@@ -436,7 +418,7 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 120.
 ##
 ## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##

--- a/parser.mly
+++ b/parser.mly
@@ -140,9 +140,8 @@ instruction:
   { Clear x }
 | PRINT e=expression
   { Print e }
-| OSR
-  e=expression f=label v=label l=label LBRACKET xs=separated_list(COMMA, osr_def) RBRACKET
-  { Osr (e, f, v, l, xs) }
+| OSR cond=expression LPAREN f=label COMMA v=label COMMA l=label RPAREN LBRACKET xs=separated_list(COMMA, osr_def) RBRACKET
+  { Osr {cond; target= {func=f; version=v; label=l}; map=xs} }
 | STOP e=expression
   { Stop e }
 | s=COMMENT

--- a/rename.ml
+++ b/rename.ml
@@ -84,10 +84,8 @@ let uses_in_instruction old_name new_name instr : instruction =
     Print (in_expression exp)
   | Branch (exp, l1, l2) ->
     Branch (in_expression exp, l1, l2)
-  | Osr (exp, f, v, l, osrs) ->
-    Osr (in_expression exp, f, v, l,
-         List.map in_osr osrs)
-
+  | Osr {cond; target; map} ->
+    Osr {cond = in_expression cond; target; map = List.map in_osr map}
   | Decl_mut (x, None)
   | Read x ->
     assert (x != old_name);

--- a/tests.ml
+++ b/tests.ml
@@ -291,7 +291,7 @@ version anon_1
  mut x = 9
  mut y = 10
  mut r = 1
- osr (x == y) main anon l1 [mut r, mut x, mut y]
+ osr (x == y) (main, anon, l1) [mut r, mut x, mut y]
  r <- 3
  print r
  clear r
@@ -1262,6 +1262,23 @@ let test_functions () =
     |pr} 22);
   ();;
 
+let test_deopt () =
+  let test str n =
+    run (parse str) no_input (returns (Int n)) () in
+  test {pr|
+    function main ()
+    version a
+     const x = 1
+     osr (x==1) (main, b, l) [const y=42]
+     return x
+
+    version b
+     const y = 2
+    l:
+     return y
+  |pr} 42;
+  ()
+
 let suite =
   "suite">:::
   ["mut">:: run test_mut no_input
@@ -1328,7 +1345,7 @@ let suite =
    "parser3">:: test_parse_disasm  ("const x = (y + x)\n");
    "parser4">:: test_parse_disasm  ("x <- (x == y)\n");
    "parser5">:: test_parse_disasm  ("# asdfasdf\n");
-   "parser5b">:: test_parse_disasm ("osr (x == y) f v l [const x = x, mut y = x, mut v, const x = (1+2)]\nl:\n");
+   "parser5c">:: test_parse_disasm ("osr (x==1) (f, v, l) [const x = x, mut y = x, mut v, const x = (1+2)]\nl:\n");
    "parser6">:: test_parse_disasm  ("branch (x == y) as fd\n");
    "parser7">:: test_parse_disasm  ("const x = (y + x)\n x <- (x == y)\n# asdfasdf\nbranch (x == y) as fd\n");
    "parser8">:: test_parse_disasm_file "examples/sum.sou";
@@ -1353,6 +1370,7 @@ let suite =
    "pull_drop">:: do_test_pull_drop;
    "move_drop">:: do_test_drop_driver;
    "test_functions">:: test_functions;
+   "test_deopt">:: test_deopt;
    ]
 ;;
 

--- a/transform.ml
+++ b/transform.ml
@@ -69,7 +69,7 @@ let branch_prune (func : afunction) : afunction =
               (ModedVarSet.elements scope)
           in
           branch_prune pc'
-            (Goto l2 :: Osr (exp, func.name, version.label, l1, osr) :: acc)
+            (Goto l2 :: Osr {cond=exp; target={func=func.name; version=version.label; label=l1}; map=osr} :: acc)
         | i ->
           branch_prune pc' (i::acc)
         end


### PR DESCRIPTION
This fell out of a different (abandoned) change. Since imho the syntax slightly improved I am proposing the following change.

Syntax is new `osr e (f,v,l) [map]` instead of `osr e f v l [map]`. Also the internal representation uses a struct instead of a tuple to make matching a bit more intuitive.