### PR TITLE
Assumptions

### DIFF
--- a/disasm.ml
+++ b/disasm.ml
@@ -55,17 +55,17 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     | Goto label                      -> pr buf " goto %s" label
     | Print exp                       -> pr buf " print %a" dump_expr exp
     | Read var                        -> pr buf " read %s" var
-    | Osr (exp, f, v, l, vars)        ->
+    | Osr {cond; target = {func; version; label}; map} ->
       let dump_var buf = function
         | Osr_const (x, e)     -> pr buf "const %s = %a" x dump_expr e
         | Osr_mut (x, e)       -> pr buf "mut %s = %a" x dump_expr e
         | Osr_mut_ref (x, y)   -> pr buf "mut %s = &%s" x y
         | Osr_mut_undef x      -> pr buf "mut %s" x
       in
-      pr buf " osr %a %s %s %s [%a]"
-        dump_expr exp
-        f v l
-        (dump_comma_separated dump_var) vars
+      pr buf " osr [%a] (%s, %s, %s) [%a]"
+        (dump_comma_separated dump_expr) cond
+        func version label
+        (dump_comma_separated dump_var) map
     | Comment str                     -> pr buf " #%s" str
     end;
     pr buf "\n"

--- a/doc/assumptions.md
+++ b/doc/assumptions.md
@@ -1,0 +1,218 @@
+# Inserting Assumptions
+
+This documents describes the rationale behind the transformations in
+`Transform_assumption`.
+
+In the following discussion we call the instruction pair composed of a
+label and an osr instruction a checkpoint. For example:
+
+```
+checkpoint_2:
+  osr [] (f,v,checkpoint_2) [...]
+```
+
+There are 3 primitive operations regarding assumptions:
+
+1. Insert Checkpoints
+2. Create a new Version
+3. Insert an Assumption
+
+The following assumes that all instructions belong to the function `f` and
+the initial version is called `v`.
+
+## 1. Insert Checkpoints
+
+Before we can add assumptions to a program we need to establish the
+initial relation between the different versions of the program. Initially we
+achieve this by adding all possible checkpoints (they can be trimmed later).
+
+    I   = i*
+    I' := (label lᵢ ; checkpoint [] (f,v,lᵢ) Δᵢ ; i)*
+    lᵢ  - fresh
+    Δᵢ := { x ↤ x | ∀ x ∈ S(I', lᵢ) }
+    -----------------------------------------   (init)
+    I'
+
+## 2. Create a new Version
+
+In the most general case we have to be able to osr to the initial version.
+Therefore we should always keep the baseline version untouched. But also
+for intermediate steps we might wish to be able to peel off one assumption
+at a time.
+
+Creating a new version duplicates the active version and updates all osr
+targets.
+
+    (..., v ↦ I)
+    I' := I[osr _ (f,_,l) _ / osr _ (f,v,l)]
+           ∀   l - checkpoint label in I
+    v' - fresh version label
+    ------------------------------------------   (next)
+    (..., v ↦ I, v' ↦ I')
+
+## 3. Insert an Assumption
+
+We can insert assumptions at every checkpoint
+
+    I
+    l - checkpoint label in I
+    e' - valid
+    I[l] = osr [e, ...] _ _
+    ---------------------------------   (asm)
+    I[l ↦ osr [e', e, ...] _ _]
+
+### Example
+
+Input program
+
+    function main
+    version v
+      1: y = 1
+      2: x = read
+      3: branch (x=0) 4 5
+      4: y = 2
+      5: branch (y=x) 6 7
+      6: print y
+      7: stop
+
+(init)
+
+    function main
+    version v
+      1: y = 1
+      2: x = read
+      3: checkpoint_1:
+         osr [] (main, v, checkpoint_1) [y=y, x=x]
+         branch (x=0) 4 5
+      4: y = 2
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=y, x=x]
+         branch (y=x) 6 7
+      6: print y
+      7: stop
+
+(next)
+
+    function main
+    version v'
+      1: y = 1
+      2: x = read
+      3: checkpoint_1:
+         osr [] (main, v, checkpoint_1) [y=y, x=x]
+         branch (x=0) 4 5
+      4: y = 2
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=y, x=x]
+         branch (y=x) 6 7
+      6: print y
+      7: stop
+    version v
+      1: y = 1
+      2: x = read
+      3: checkpoint_1:
+         osr [] (main, v, checkpoint_1) [y=y, x=x]
+         branch (x=0) 4 5
+      4: y = 2
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=y, x=x]
+         branch (y=x) 6 7
+      6: print y
+      7: stop
+
+(asm) :  Speculate `x != 0`
+
+    function main
+    version v'
+      1: y = 1
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v, checkpoint_1) [y=y, x=x]
+         branch (x=0) 4 5
+      4: y = 2
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=y, x=x]
+         branch (y=x) 6 7
+      6: print y
+      7: stop
+    version v
+      ...
+
+`branch (x=0)` must be false. Therefore remove the true branch.
+
+    function main
+    version v'
+      1: y = 1
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v, checkpoint_1) [y=y, x=x]
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=y, x=x]
+         branch (y=x) 6 7
+      6: print y
+      7: stop
+    version v
+      ...
+
+constant folding:
+
+    function main
+    version v'
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v, checkpoint_1) [y=1, x=x]
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=1, x=x]
+         branch (1=x) 6 7
+      6: print 1
+      7: stop
+    version v
+      ...
+
+(next) + (asm) :  Speculate `x != 1`
+
+    function main
+    version v''
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v', checkpoint_1) [y=1, x=x]
+      5: checkpoint_2:
+         osr [x=1] (main, v', checkpoint_2) [y=1, x=x]
+         branch (1=x) 6 7
+      6: print 1
+      7: stop
+    version v'
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v, checkpoint_1) [y=1, x=x]
+      5: checkpoint_2:
+         osr [] (main, v, checkpoint_2) [y=1, x=x]
+         branch (1=x) 6 7
+      6: print 1
+      7: stop
+    version v
+      ...
+
+remove unreachable code (branch (1=x) must be false):
+
+    function main
+    version v''
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0] (main, v', checkpoint_1) [y=1, x=x]
+      5: checkpoint_2:
+         osr [x=1] (main, v', checkpoint_2) [y=1, x=x]
+      7: stop
+    version v'
+      ...
+
+hoist assumptions to the earliest possible checkpoint and remove unused checkpoints
+
+    function main
+    version v''
+      2: x = read
+      3: checkpoint_1:
+         osr [x=0, x=1] (main, v', checkpoint_1) [y=1, x=x]
+      7: stop
+    version v'
+      ...
+

--- a/edit.ml
+++ b/edit.ml
@@ -158,9 +158,9 @@ let replace_uses_in_instruction old_name new_name instr : instruction =
   | Branch (exp, l1, l2) ->
     Branch (in_expression exp, l1, l2)
   | Osr {cond; target; map} ->
-    Osr {cond = List.map in_expression cond;
-         target;
-         map = List.map in_osr map}
+    let cond = List.map in_expression cond in
+    let map = List.map in_osr map in
+    Osr {cond; target; map}
   | Decl_mut (x, None)
   | Read x ->
     assert (x != old_name);

--- a/edit.ml
+++ b/edit.ml
@@ -157,10 +157,10 @@ let replace_uses_in_instruction old_name new_name instr : instruction =
     Print (in_expression exp)
   | Branch (exp, l1, l2) ->
     Branch (in_expression exp, l1, l2)
-  | Osr (exp, f, v, l, osrs) ->
-    Osr (in_expression exp, f, v, l,
-         List.map in_osr osrs)
-
+  | Osr {cond; target; map} ->
+    Osr {cond = List.map in_expression cond;
+         target;
+         map = List.map in_osr map}
   | Decl_mut (x, None)
   | Read x ->
     assert (x != old_name);

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -11,7 +11,7 @@ version active
  mut x = 30
  mut z = 0
  read z
- osr (z == zero) main old l1 [const one = one, const two = two, mut w1 = &w1, mut w2 = &w2, mut x = &x, mut z = &z, const zero = zero]
+ osr [(z == zero)] (main,old,l1) [const one = one, const two = two, mut w1 = &w1, mut w2 = &w2, mut x = &x, mut z = &z, const zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)

--- a/examples/complicated.sou
+++ b/examples/complicated.sou
@@ -1,0 +1,12 @@
+ mut x
+ mut y = 1
+ read x
+ mut i = 0
+loop:
+  branch (x==1) c1 c2
+ c1:
+  y <- 2
+ c2:
+  i <- (i+y)
+ branch (i==10) end loop
+end:

--- a/instr.ml
+++ b/instr.ml
@@ -69,6 +69,8 @@ end
 
 type pc = Pc.t
 
+type unique_pos = {func : label; version : label; label : label;}
+
 type instructions = instruction array
 and instruction =
   | Decl_const of variable * expression
@@ -84,8 +86,8 @@ and instruction =
   | Label of label
   | Goto of label
   | Print of expression
-  | Osr of expression * label * label * label * osr_def list
   | Stop of expression
+  | Osr of {cond : expression list; target : unique_pos; map : osr_def list; }
   | Comment of string
 and osr_def =
   | Osr_const of variable * expression
@@ -182,6 +184,10 @@ let arg_vars = function
   | Arg_by_val e -> expr_vars e
   | Arg_by_ref x -> VarSet.singleton x
 
+let list_vars ls =
+  let vs = List.map expr_vars ls in
+  List.fold_left VarSet.union VarSet.empty vs
+
 let declared_vars = function
   | Call (x, _, _)
   | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
@@ -222,14 +228,13 @@ let required_vars = function
   | Label _l | Goto _l -> VarSet.empty
   | Comment _ -> VarSet.empty
   | Print e -> expr_vars e
-  | Osr (e, _, _, _, osr) ->
+  | Osr {cond; map} ->
     let exps = List.map (function
         | Osr_const (_, e) -> e
         | Osr_mut (_, e) -> e
         | Osr_mut_ref (_, x) -> Simple (Var x)
-        | Osr_mut_undef _ -> Simple (Constant Nil)) osr in
-    let exps_vars = List.map expr_vars exps in
-    List.fold_left VarSet.union (expr_vars e) exps_vars
+        | Osr_mut_undef _ -> Simple (Constant Nil)) map in
+    VarSet.union (list_vars cond) (list_vars exps)
 
 let defined_vars = function
   | Call (x, _, _)
@@ -312,14 +317,13 @@ let used_vars = function
   | Goto _
   | Comment _
   | Read _ -> VarSet.empty
-  | Osr (e, _, _, _, osr) ->
+  | Osr {cond; map} ->
     let exps = List.map (function
         | Osr_const (_, e) -> e
         | Osr_mut (_, e) -> e
         | Osr_mut_ref (_, x) -> Simple (Var x)
-        | Osr_mut_undef _ -> Simple (Constant Nil)) osr in
-    let exps_vars = List.map expr_vars exps in
-    List.fold_left VarSet.union (expr_vars e) exps_vars
+        | Osr_mut_undef _ -> Simple (Constant Nil)) map in
+    VarSet.union (list_vars cond) (list_vars exps)
 
 exception FunctionDoesNotExist of identifier
 

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 121.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 120.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 119.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,7 +43,7 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: CONST IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 100.
 ##
 ## instruction -> CONST variable EQUAL . expression [ NEWLINE ]
 ##
@@ -57,7 +57,7 @@ example "(x + 1)", is now expected to construct a constant declaration
 
 program: CONST IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 99.
 ##
 ## instruction -> CONST variable . EQUAL expression [ NEWLINE ]
 ##
@@ -71,7 +71,7 @@ Parsing an instruction, we parsed "const <var>" so far; the equal sign
 
 program: CONST TRIPLE_DOT 
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 98.
 ##
 ## instruction -> CONST . variable EQUAL expression [ NEWLINE ]
 ##
@@ -85,7 +85,7 @@ example "x", is now expected to construct a constant declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 94.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +99,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 124.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,7 +113,7 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 93.
 ##
 ## label -> IDENTIFIER . [ COLON ]
 ## variable -> IDENTIFIER . [ LEFTARROW ]
@@ -126,93 +126,103 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 - if this is a label declaration, we expect a semicolon: "<label>:"
 - if this is an assignment, we expect a left arrow: "<var> <- <expression>"
 
-program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER TRIPLE_DOT 
+program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
+##
+## Ends in an error in state: 69.
+##
+## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET 
+##
+
+There was an error parsing the specification of the new environment of an
+osr instruction. The specification is a comma-separated list of terms of the form
+"const x = e" (where "e" is an expression), "mut x = e", "mut x = &y"
+or just "mut x". For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+
+program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
+##
+## Ends in an error in state: 68.
+##
+## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+##
+## The known suffix of the stack is as follows:
+## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
+##
+
+After "osr [...] (...) " we expect the specification of the new environment.
+It is a square bracket enclosed, comma-separated list
+of terms of the form "const x = e" (where "e" is an expression),
+"mut x = e", "mut x = &y" or just "mut x". For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+
+
+program: OSR LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
 ##
 ## Ends in an error in state: 61.
 ##
-## instruction -> OSR expression label label label . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR expression label label label 
+## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
 ##
 
-Parsing the specification of the new environment of an osr instruction
-failed. After "osr <function> <version> <label>" we expect an
-environment mapping as a square bracket enclosed, comma-separated list
-of terms of the form "const x = e" (where "e" is an expression),
-"mut x = e", "mut x = &y" or just "mut x". For example,
-"osr Main optimized l2 [const x = e, mut y = &y, mut z]".
+Parsing an osr instruction, there is an error with the syntax of the target
+location "(function, version, label)".
+The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR NIL IDENTIFIER IDENTIFIER IDENTIFIER LBRACKET TRIPLE_DOT 
+program: OSR LBRACKET NIL RBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 60.
 ##
-## instruction -> OSR expression label label label LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR expression label label label LBRACKET 
+## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
 ##
 
-Parsing the specification of the new environment of an osr instruction
-failed. After "osr <function> <version> <label> [" we expect an
-environment mapping as a comma-separated list of terms of the form
-"const x = e" (where "e" is an expression), "mut x = e", "mut x = &y"
-or just "mut x". For example,
-"osr Main optimized l2 [const x = e, mut y = &y, mut z]".
+Parsing an osr instruction, we parsed "osr [<expr> ...]", and are
+now expecting a target location "(function, version, label)".
+The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR NIL IDENTIFIER TRIPLE_DOT 
-##
-## Ends in an error in state: 59.
-##
-## instruction -> OSR expression label . label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
-##
-## The known suffix of the stack is as follows:
-## OSR expression label 
-##
-
-Parsing an osr instruction, we parsed "osr <expr> <version>", and are
-now expecting a label. The complete instruction syntax is "osr <expr>
-<version> <label> [<new_env>]", where "<new_env>" is a specification
-of the environment mapping. It's a comma-separated list of terms of
-the form "const x = e" (where "e" is an expression), "mut x = e",
-"mut x = &y" or just "mut x". For example,
-"osr Main optimized l2 [const x = e, mut y = &y, mut z]".
-
-program: OSR NIL TRIPLE_DOT 
+program: OSR LBRACKET TRIPLE_DOT 
 ##
 ## Ends in an error in state: 57.
 ##
-## instruction -> OSR expression . label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR expression 
+## OSR LBRACKET 
 ##
 
-Parsing an osr instruction, we parsed "osr <expr>", and are now
-expecting a version label, for example "foo". The complete instruction
-syntax is "osr <expr> <version> <label> [<new_env>]", where
-"<new_env>" is a specification of the environment mapping. It's
-a comma-separated list of terms of the form "const x = e" (where "e"
-is an expression), "mut x = e", "mut x = &y" or just "mut x". For
-example, "osr Main optimized l2 [const x = e, mut y = &y, mut z]".
+Parsing an osr instruction, there was an error parsing the list of conditions.
+Conditions are expressions like "(x == 2)".
+The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+
 
 program: OSR TRIPLE_DOT 
 ##
 ## Ends in an error in state: 56.
 ##
-## instruction -> OSR . expression label label label LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR . LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR 
 ##
 
-Parsing an osr instruction, we parsed "osr", and are now expecting an
-expression, for example "(x + 1)". The complete instruction syntax is
-"osr <expr> <version> <label> [<new_env>]", where "<new_env>" is
-a specification of the new environment. It's a comma-separated list of
-terms of the form "const x = e" (where "e" is an expression),
-"mut x = e", "mut x = &y" or just "mut x". For example,
-"osr Main optimized l2 [const x = e, mut y = &y, mut z]".
+Parsing an osr instruction, we parsed "osr", and are now expecting a bracket
+enclosed list of conditions. Conditions are expressions like "(x == 2)".
+The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+For example,
+"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 program: LBRACE IDENTIFIER COMMA STOP 
 ##
@@ -294,7 +304,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: MUT IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 91.
 ##
 ## instruction -> MUT variable EQUAL . expression [ NEWLINE ]
 ##
@@ -308,7 +318,7 @@ construct a constant mutable instruction "mut <var> = <expr>".
 
 program: MUT IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 90.
 ##
 ## instruction -> MUT variable . [ NEWLINE ]
 ## instruction -> MUT variable . EQUAL expression [ NEWLINE ]
@@ -323,7 +333,7 @@ instruction "mut <var> = <expr>".
 
 program: MUT TRIPLE_DOT 
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 89.
 ##
 ## instruction -> MUT . variable [ NEWLINE ]
 ## instruction -> MUT . variable EQUAL expression [ NEWLINE ]
@@ -425,7 +435,7 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 129.
 ##
 ## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##
@@ -438,7 +448,7 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 128.
 ##
 ## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP CONST COMMENT CLEAR CALL BRANCH ]
 ##

--- a/parser.mly
+++ b/parser.mly
@@ -146,9 +146,8 @@ instruction:
   { Clear x }
 | PRINT e=expression
   { Print e }
-| OSR
-  e=expression f=label v=label l=label LBRACKET xs=separated_list(COMMA, osr_def) RBRACKET
-  { Osr (e, f, v, l, xs) }
+| OSR LBRACKET cs=separated_list(COMMA, expression) RBRACKET LPAREN f=label COMMA v=label COMMA l=label RPAREN LBRACKET xs=separated_list(COMMA, osr_def) RBRACKET
+  { Osr {cond=cs; target= {func=f; version=v; label=l}; map=xs} }
 | STOP e=expression
   { Stop e }
 | s=COMMENT

--- a/sourir.ml
+++ b/sourir.ml
@@ -27,6 +27,8 @@ let () =
       exit 2
   in
 
+  opts := if !opts = ["all"] then Transform.all_opts else !opts;
+
   begin try Scope.check_program program with
   | Scope.ScopeExceptionAt (f, v, e) ->
     begin
@@ -134,7 +136,13 @@ let () =
     exit 1
   end;
 
-  let program = Transform.(try_opt (optimize !opts) program) in
+  let program = try Transform.(try_opt (optimize !opts) program) with
+    | Transform.UnknownOptimization opt ->
+      Printf.eprintf "Unknown optimization %s.\nValid optimizers are %s\n"
+        opt (String.concat ", " Transform.all_opts);
+      exit 1
+  in
+
   if not !quiet then begin
     Printf.printf "After optimizations\n";
     Disasm.disassemble_o stdout program

--- a/tests.ml
+++ b/tests.ml
@@ -291,7 +291,7 @@ version anon_1
  mut x = 9
  mut y = 10
  mut r = 1
- osr (x == y) main anon l1 [mut r, mut x, mut y]
+ osr [(x == y)] (main, anon, l1) [mut r, mut x, mut y]
  r <- 3
  print r
  clear r
@@ -1329,7 +1329,7 @@ let do_test_deopt () =
     function main ()
     version a
      const x = 1
-     osr (x==1) main b l [const y=42]
+     osr [(x==1)] (main, b, l) [const y=42]
      return x
 
     version b
@@ -1345,7 +1345,7 @@ let do_test_deopt () =
      return aliased
     function foo(mut x)
     version vers_a
-     osr (1==1) foo vers_b st [mut x = &x]
+     osr [(1==1)] (foo,vers_b,st) [mut x = &x]
      return 0
     version vers_b
      st:
@@ -1360,7 +1360,7 @@ let do_test_deopt () =
      return aliased
     function foo(mut x)
     version vers_a
-     osr (1==1) foo vers_b st [mut x = x]
+     osr [(1==1)] (foo,vers_b,st) [mut x = x]
      return 0
     version vers_b
      st:
@@ -1374,15 +1374,13 @@ let do_test_deopt () =
      return x
     function foo()
     version vers_a
-     osr (1==1) foo vers_b st [mut x = (41 + 1)]
+     osr [(1==1)] (foo,vers_b,st) [mut x = (41 + 1)]
      return 0
     version vers_b
      mut x = 0
      st:
      return x
   |pr} 42;
-
-
   ()
 
 let suite =
@@ -1451,7 +1449,7 @@ let suite =
    "parser3">:: test_parse_disasm  ("const x = (y + x)\n");
    "parser4">:: test_parse_disasm  ("x <- (x == y)\n");
    "parser5">:: test_parse_disasm  ("# asdfasdf\n");
-   "parser5b">:: test_parse_disasm ("osr (x == y) f v l [const x = x, mut y = &x, mut v, const x = (1+2)]\nl:\n");
+   "parser5b">:: test_parse_disasm ("osr [(x == y)] (f, v, l) [const x = x, mut y = &x, mut v, const x = (1+2)]\nl:\n");
    "parser6">:: test_parse_disasm  ("branch (x == y) as fd\n");
    "parser7">:: test_parse_disasm  ("const x = (y + x)\n x <- (x == y)\n# asdfasdf\nbranch (x == y) as fd\n");
    "parser8">:: test_parse_disasm_file "examples/sum.sou";

--- a/transform.ml
+++ b/transform.ml
@@ -70,6 +70,8 @@ let optimistic_as_opt_function (transformation : create_optimistic_version)
       let version = { version with instrs = cleaned } in
       Some { func with body = version :: func.body }
 
+
+
 (* All available optimizations *)
 let cleanup_all_instrs = combine_transform_instructions [
     Transform_cleanup.remove_unreachable_code;
@@ -89,13 +91,16 @@ let minimize_liverange = as_opt_function minimize_liverange_instrs
 let hoist_assignment = as_opt_function Transform_hoist_assign.hoist_assignment
 let hoist_drop = as_opt_function Transform_hoist.Drop.apply
 let branch_prune = optimistic_as_opt_function
-    Transform_assumption.insert_branch_pruning_assumption
+    Transform_prune.insert_branch_pruning_assumption
     (combine_transform_instructions [
-       Transform_cleanup.remove_unreachable_code;
-       Transform_cleanup.remove_jmp;])
+       Transform_prune.branch_prune;
+       Transform_cleanup.remove_unreachable_code;])
 
 (* Main optimizer loop *)
 exception UnknownOptimization of string
+
+let all_opts = ["prune";"make_const";"const_prop";"hoist_assign";"hoist_drop";"min_live"]
+let assumption_opts = ["prune"]
 
 let optimize (opts : string list) (prog : program) : program option =
   let optimizer = function
@@ -114,10 +119,21 @@ let optimize (opts : string list) (prog : program) : program option =
     | o ->
       raise (UnknownOptimization o)
   in
-  let opts =
-    if opts = ["all"]
-    then ["prune";"make_const";"const_prop";"hoist_assign";"hoist_drop";"min_live"]
-    else opts in
+  let opts_assumpt, opts_other = List.partition (fun o -> List.mem o assumption_opts) opts in
   let optimizers = (List.map optimizer opts) @ [(as_opt_program cleanup_all)] in
+  let optimizers_classic = (List.map optimizer opts_other) @ [(as_opt_program cleanup_all)] in
   let optimizer = combine_opt optimizers in
+  let optimizer_classic = combine_opt optimizers_classic in
+
+  let optimizer =
+    if opts_assumpt <> []
+    then combine_opt [
+        (as_opt_program Transform_assumption.insert_checkpoints);
+        optimizer;
+        (as_opt_program (as_opt_function Transform_assumption.remove_empty_osr));
+        (as_opt_program (as_opt_function Transform_assumption.remove_checkpoint_labels));
+        optimizer_classic;
+      ]
+    else optimizer
+  in
   optimizer prog

--- a/transform.ml
+++ b/transform.ml
@@ -130,6 +130,8 @@ let optimize (opts : string list) (prog : program) : program option =
     then combine_opt [
         (as_opt_program Transform_assumption.insert_checkpoints);
         optimizer;
+        (as_opt_program (as_opt_function Transform_assumption.hoist_assumption));
+        optimizer;
         (as_opt_program (as_opt_function Transform_assumption.remove_empty_osr));
         (as_opt_program (as_opt_function Transform_assumption.remove_checkpoint_labels));
         optimizer_classic;

--- a/transform_assumption.ml
+++ b/transform_assumption.ml
@@ -1,38 +1,129 @@
 open Instr
 open Transform_utils
 
-let result_version (func : afunction) (label : label) (instrs : instructions) : version =
-  { label = Edit.fresh_version_label func label;
-    instrs;
-    annotations = None }
+(* Inserts checkpoints at all program points
+ * A checkpoint is a well-formed osr point and a matching label.
+ * For example:
+ *   checkpoint_1:
+ *     osr [] (func, version, checkpoint_1) [mut x = &x]
+ * Initially the checkpoint is self referential (ie. its target is
+ * the label right above. Insert assumption makes use of this property
+ * to create a new version where the checkpoints are in sync.
+ * This has to run before any optimistic optimizations. *)
+let insert_checkpoints (func:afunction) =
+  (* Can only insert checkpoints into an unoptimized function *)
+  if List.length func.body <> 1 then None else
 
-let insert_branch_pruning_assumption (func : afunction) : version option =
-  let version = Instr.active_version func in
+  let version = List.hd func.body in
   let instrs = version.instrs in
   let inp = Analysis.as_analysis_input func version in
   let scope = Scope.infer inp in
   let live = Analysis.live inp in
+
   let transform pc =
-    match scope.(pc) with
-    | DeadScope -> assert(false)
-    | Scope scope ->
-      begin match[@warning "-4"] instrs.(pc) with
-      | Branch (exp, l1, l2) ->
+    let create_checkpoint pc =
+      match scope.(pc) with
+      | DeadScope -> assert(false)
+      | Scope scope ->
         let osr = List.map (function
-            | (Const_var, x) ->
-              Osr_const (x, (Simple (Var x)))
-            | (Mut_var, x) ->
-              if List.mem x (live pc) then
-                Osr_mut_ref (x,  x)
-              else
-                Osr_mut_undef x)
-            (ModedVarSet.elements scope)
-        in
-        let target = { func=func.name; version=version.label; label=l1 } in
-        Insert [Osr {cond=[exp]; target; map=osr}; Goto l2]
-      | _ -> Unchanged
-      end
+          | (Const_var, x) -> Osr_const (x, (Simple (Var x)))
+          | (Mut_var, x)   ->
+            if List.mem x (live (pc-1)) then
+              Osr_mut_ref (x, x)
+            else
+              Osr_mut_undef x) (ModedVarSet.elements scope) in
+        let target = { func=func.name; version=version.label; label=checkpoint_label pc } in
+        Insert [Label (checkpoint_label pc); Osr {cond=[]; target; map=osr};]
+    in
+    if pc = 0 then Unchanged else
+    match[@warning "-4"] instrs.(pc) with
+    | Stop _ | Return _ | Label _ | Comment _ -> Unchanged
+    | Osr _ -> assert false
+    | _ -> create_checkpoint pc
   in
-  match change_instrs transform inp with
+  let baseline = change_instrs transform inp in
+  let (|?) opt def = match opt with Some v -> v | None -> def in
+  Some { func with
+         body = [
+           { label = version.label;
+             instrs = (|?) baseline instrs;
+             annotations = None } ] }
+
+let remove_empty_osr ({instrs} as inp) : instructions option =
+  let transform pc =
+    match[@warning "-4"] instrs.(pc) with
+    | Osr {cond} when cond = [] -> Remove 1
+    | _ -> Unchanged
+  in
+  change_instrs transform inp
+
+(* TODO: replace this by a pass which does a global program transformation
+ * and checks if the labels are really unused. *)
+(* Removes all checkpoint labels. Can be applied as a final cleanup
+ * when there are no osr-in points. *)
+let remove_checkpoint_labels ({instrs} as inp) : instructions option =
+  let transform pc =
+    match[@warning "-4"] instrs.(pc) with
+    | Label l when is_checkpoint_label l -> Remove 1
+    | _ -> Unchanged
+  in
+  change_instrs transform inp
+
+(* Inserts the assumption that osr_condition is false at position pc.
+ * The approach is to
+ * 1. Create a new version. This is a copy of the current one where all
+ *    the osr targets point one version down (ie. to the current one).
+ * 2. Starting from pc walk up the cfg and find the earliest possible
+ *    checkpoint for the osr_condition. Branch targets are blocking as
+ *    are instructions which interfere with the osr_condition. The
+ *    condition has to be added to an existing osr instruction (see
+ *    insert_checkpoints above). *)
+let insert_assumption (func : afunction) osr_cond pc : version option =
+  (* This takes the active version and duplicates it. Osr targets are
+   * updated to point to the currently active version *)
+  let next_version (func:afunction) =
+    let cur_version = Instr.active_version func in
+    let transform pc =
+      match[@warning "-4"] cur_version.instrs.(pc) with
+      | Osr {cond; target={func; version; label}; map} ->
+        let target = {func; version = cur_version.label; label} in
+        Replace (Osr {cond; target; map})
+      | _ -> Unchanged
+    in
+    let inp = Analysis.as_analysis_input func cur_version in
+    { label = Edit.fresh_version_label func cur_version.label;
+      instrs = (match change_instrs transform inp with | None -> cur_version.instrs | Some i -> i);
+      annotations = None }
+  in
+
+  let version = next_version func in
+  let instrs = version.instrs in
+  let preds = Analysis.predecessors version.instrs in
+  (* Finds the highest up osr checkpoint in that basic block where the
+   * assumption can be placed. *)
+  let rec find_candidate_osr cond_vars pc acc =
+    if pc = 0 then acc else
+    match[@warning "-4"] instrs.(pc) with
+    | Osr _ -> find_candidate_osr cond_vars (pc-1) (Some pc)
+    | Label _ ->
+      begin match[@warning "-4"] preds.(pc) with
+      | [pred] -> find_candidate_osr cond_vars pred acc
+      | _ -> acc
+      end
+    | _ ->
+      assert (preds.(pc) = [pc-1]);
+      if Instr.independent instrs.(pc) osr_cond
+      then find_candidate_osr cond_vars (pc-1) acc
+      else acc
+  in
+  let osr_vars = expr_vars osr_cond in
+  begin match find_candidate_osr osr_vars (pc-1) None with
   | None -> None
-  | Some instrs -> Some (result_version func version.label instrs)
+  | Some pc ->
+    begin match[@warning "-4"] instrs.(pc) with
+    | Osr {cond; target; map} ->
+      instrs.(pc) <- Osr {cond=osr_cond::cond; target; map};
+      Some { version with instrs }
+    | _ -> assert (false)
+    end
+  end

--- a/transform_assumption.ml
+++ b/transform_assumption.ml
@@ -28,7 +28,8 @@ let insert_branch_pruning_assumption (func : afunction) : version option =
                 Osr_mut_undef x)
             (ModedVarSet.elements scope)
         in
-        Insert [Osr (exp, func.name, version.label, l1, osr); Goto l2]
+        let target = { func=func.name; version=version.label; label=l1 } in
+        Insert [Osr {cond=[exp]; target; map=osr}; Goto l2]
       | _ -> Unchanged
       end
   in

--- a/transform_cleanup.ml
+++ b/transform_cleanup.ml
@@ -9,7 +9,10 @@ let remove_jmp ({instrs} as inp : analysis_input) : instructions option =
     match[@warning "-4"] instrs.(pc), instrs.(pc+1) with
     | Goto l1, Label l2 when l1 = l2 && List.length pred.(pc+1) = 1 ->
       Remove 2
-    | Label _, _ when pred.(pc) = [pc-1] && succ.(pc-1) = [pc] ->
+    | Label l, _ when
+        pred.(pc) = [pc-1] &&
+        succ.(pc-1) = [pc] &&
+        not (is_checkpoint_label l) ->
         (* A label is unused if the previous instruction is the only predecessor
          * unless the previous instruction jumps to it. The later can happen
          * if its a goto (then we already remove it -- see above) or if its a branch (which

--- a/transform_prune.ml
+++ b/transform_prune.ml
@@ -1,0 +1,29 @@
+open Instr
+open Transform_utils
+
+let insert_branch_pruning_assumption (func : afunction) : version option =
+  let version = Instr.active_version func in
+  let instrs = version.instrs in
+  (* Finds the first branch instruction in the stream *)
+  let rec find_branch pc =
+    if pc = Array.length instrs then None else
+    match[@warning "-4"] instrs.(pc) with
+    | Branch (exp, l1, l2) -> Some (pc, exp)
+    | _ -> find_branch (pc+1)
+  in
+  match find_branch 0 with
+  | None -> None
+  | Some (pc, branch_cond) ->
+    Transform_assumption.insert_assumption func branch_cond pc
+
+let branch_prune ({instrs} as inp) : instructions option =
+  let assumptions = Analysis.valid_assumptions inp in
+  let transform pc =
+    match[@warning "-4"] instrs.(pc) with
+    | Branch (e, l1, l2) ->
+      if Analysis.ExpressionSet.mem e (assumptions pc)
+      then Replace (Goto l2)
+      else Unchanged
+    | _ -> Unchanged
+  in
+  change_instrs transform inp

--- a/transform_utils.ml
+++ b/transform_utils.ml
@@ -3,6 +3,7 @@ open Instr
 type instruction_change =
   | Remove of int
   | Insert of instruction list
+  | InsertAfter of instruction list
   | Replace of instruction
   | Unchanged
 
@@ -18,6 +19,8 @@ let change_instrs (transform : pc -> instruction_change) ({formals; instrs} : an
         acc_instr (pc+1) (i :: acc) true
       | Insert is ->
         acc_instr (pc+1) (instrs.(pc) :: (List.rev is) @ acc) true
+      | InsertAfter is ->
+        acc_instr (pc+1) ((List.rev is) @ instrs.(pc) :: acc) true
       | Unchanged ->
         acc_instr (pc+1) (instrs.(pc)::acc) changed
   in


### PR DESCRIPTION
This PR abandons the good old branch pruning and replaces it with a more generalized version.

The first commit adds multiple osr conditions to a single osr instruction. The new syntax is `osr [condition, ...] (target) [osr-map]`. As an example `osr [(a==2), (b==4), (a<>b)] (main,old,l3) [...]`. It triggers if any of the conditions evaluates to true.

Then the big picture of the approach is to:

1. Insert checkpoints at every point in the program. Checkpoints are valid osr with empty condition list and a matching label.
2. Insert assumptions at will (ie. add an osr condition to an existing checkpoint). Assumptions can be thought of as quasi invariants we want to ensure at a certain location in the program.
3. Use the assumptions for optimizations. At location x, as long as all intermediate instructions (on all possible traces) between a guarding osr and x do not interfere with an assumption it can be assumed to hold at x.
4. Remove superfluous (empty) checkpoints.

Steps 1 and 4 are universal. For step 2 many ways of coming up with good assumptions are conceivable. Step 3 applies to any classical compiler optimization we have.

To elaborate a bit more on checkpoints. Assuming the following program:
```
version base
  mut x = 1
  return x
```
This is how it looks after checkpoint insertion:
```
version base
    mut x = 1
  checkpoint_1:
    osr [] (base, checkpoint_1) [mut x = &x]
    return x
```
To add assumptions we create new versions and let the targets point one version down
```
version base_2
    mut x = 1
  checkpoint_1:
    osr [assumption1, assumption2] (base_1, checkpoint_1) [mut x = &x]
    return x
version base_1
    mut x = 1
  checkpoint_1:
    osr [assumption1] (base, checkpoint_1) [mut x = &x]
    return x
version base
    mut x = 1
  checkpoint_1:
    osr [] (base, checkpoint_1) [mut x = &x]
    return x
```
Future work would be to merge multiple versions into two (most optimized and base). This is trivial and could be done on the fly. But conceptually I like the gradual approach (it also means you do not have to undo all assumptions at once).

The strategy for combined compiler optimization with assumption insertion is

1. Insert checkpoints
2. Run optimizers
3. Run passes which insert assumptions
4. Hoist assumptions (see below)
5. Repeat 2 - 4
6. Remove empty checkpoints
7. Run optimizers (repeat)

Step 7 is important since empty checkpoints keep potentially more variables alive than necessary (blocking optimizations). Note that theoretically after step 6 it is still possible to add new assumption. But it is not guaranteed to succeed because no fitting checkpoint might be available to insert them.

The branch_pruning is rewritten to fit this strategy. It is now performed in two passes. First a pass which inserts assumptions matching the branch conditions. And second simple optimization which turns `branch e l1 l2` into `goto l2` if e can be shown false.

Additionally, the 3rd patch introduces an optimization that hoists assumptions. If we have two osr and the intermediate instructions do not interfere we can move conditions from one to the other:
```
osr [(a=1)]
<some-instrs>
osr [(a=2)]
====>
osr [(a=1), (a=2)]
<some-instrs>
osr []
```
If in between there is a label and all predecessors except the dominating one have the assumption available, we can hoist further:
```
1   osr [(a=1)]
2  loop:           # One predecessor is dominating. The other one has the condition available.
3   osr [(a=2)]
4   <some-instrs>
5   goto loop      # (a=2) is available here if <some-instrs> do not interfere with it
====>
 osr [(a=1), (a=2)]
loop:
 osr []
 <some-instrs>
 goto loop
```

As an example of how powerful this new approach is consider the following optimization

```
 mut x
 mut y = 1
 read x
 mut i = 0
loop:
  branch (x==1) c1 c2
 c1:
  y <- 2
 c2:
  i <- (i+y)
 branch (i==10) end loop
end:
```

is optimized to

```
 mut x
 read x
 osr [(x == 1)] (main, anon_1, checkpoint_3) [mut x = &x, mut y = 1]
 mut i = 0
loop:
 i <- (i + 1)
 osr [(i == 10)] (main, anon_1, checkpoint_10) [mut i = &i, mut x = &x, mut y = 1]
 goto loop
```