### PR TITLE
fix drop hoisting across calls

### DIFF
--- a/tests.ml
+++ b/tests.ml
@@ -947,6 +947,14 @@ let do_test_push_drop () =
    l:
    " in
   test t 7 e;
+  let t = parse "
+      const a = 1
+      call x = bla ()
+      drop x
+    function bla ()
+      return 1
+   " in
+  test t 2 t;
   ()
 
 let do_test_drop_driver () =

--- a/transform_hoist.ml
+++ b/transform_hoist.ml
@@ -174,7 +174,13 @@ module Drop = struct
    *
    *)
   let is_blocking var instr =
-    VarSet.mem var (required_vars instr)
+    match[@warning "-4"] instr with
+    | Call (x, _, _) when x = var -> true
+    | _ ->
+      let blocking = VarSet.mem var (required_vars instr) in
+      let declared = VarSet.mem var (ModedVarSet.untyped (declared_vars instr)) in
+      assert (blocking || not(declared));
+      blocking
 
   let is_eliminating var instr =
     match[@warning "-4"] instr with


### PR DESCRIPTION
On a call instruction

call x = ...

x is not a required variable. It still has to block because unlike
`mut x` or `const x` it's not annihilating the call.