### PR TITLE
Constant folding

### DIFF
--- a/instr.ml
+++ b/instr.ml
@@ -49,6 +49,10 @@ module ModedVarSet = struct
     let muts = filter (fun (m,v) -> m = Mut_var) set in
     untyped muts
 
+  let consts set =
+    let consts = filter (fun (m,v) -> m = Const_var) set in
+    untyped consts
+
   let diff_untyped typed untyped =
     filter (fun (_m, x) -> not (VarSet.mem x untyped)) typed
 

--- a/tests.ml
+++ b/tests.ml
@@ -613,7 +613,7 @@ let do_test_const_fold_driver () =
     let input, expected = (parse t), (parse e) in
     let output = try_opt (as_opt_program const_fold) input in
     if (Disasm.disassemble_s output) <> (Disasm.disassemble_s expected) then begin
-      Printf.printf "input: '%s'\noutput: '%s'\nexpected: '%s'\n%!"
+      Printf.printf "\ninput: '%s'\noutput: '%s'\nexpected: '%s'\n%!"
         (Disasm.disassemble_s input)
         (Disasm.disassemble_s output)
         (Disasm.disassemble_s expected);
@@ -829,7 +829,7 @@ let do_test_const_fold_driver () =
     const a = (2 + 3)
     return a
    function g (mut m)
-    const b = 42
+    const b = (42 + 0)
     m <- b
     return m
   |input} {expect|

--- a/tests.ml
+++ b/tests.ml
@@ -860,6 +860,22 @@ let do_test_const_fold_driver () =
     print b
     return 0
   |expect};
+  (* Copy propagation of runtime consts *)
+  test {input|
+    call c = foo (0)
+    return c
+   function foo (const x)
+    const y = x
+    const z = y
+    print z
+    return z
+  |input} {expect|
+    call c = foo (0)
+    return c
+   function foo (const x)
+    print x
+    return x
+  |expect};
   ()
 
 let do_test_pull_drop () =

--- a/transform.ml
+++ b/transform.ml
@@ -79,13 +79,13 @@ let cleanup_all_instrs = combine_transform_instructions [
 let minimize_liverange_instrs = combine_transform_instructions [
     Transform_cleanup.remove_unused_decl;
     Transform_liveness.minimize_liverange; ]
-let const_prop_instrs = combine_transform_instructions [
-    Transform_constantfold.const_prop;
+let const_fold_instrs = combine_transform_instructions [
+    Transform_constantfold.const_fold;
     Transform_cleanup.remove_unused_decl;]
 
 let cleanup_all = as_opt_function cleanup_all_instrs
 let make_constant = as_opt_function Transform_constantfold.make_constant
-let const_prop = as_opt_function const_prop_instrs
+let const_fold = as_opt_function const_fold_instrs
 let minimize_liverange = as_opt_function minimize_liverange_instrs
 let hoist_assignment = as_opt_function Transform_hoist_assign.hoist_assignment
 let hoist_drop = as_opt_function Transform_hoist.Drop.apply
@@ -106,8 +106,8 @@ let optimize (opts : string list) (prog : program) : program option =
       as_opt_program hoist_drop
     | "min_live" ->
       as_opt_program minimize_liverange
-    | "const_prop" ->
-      as_opt_program const_prop
+    | "const_fold" ->
+      as_opt_program const_fold
     | "make_const" ->
       as_opt_program make_constant
     | "prune" ->
@@ -117,7 +117,7 @@ let optimize (opts : string list) (prog : program) : program option =
   in
   let opts =
     if opts = ["all"]
-    then ["prune";"make_const";"const_prop";"hoist_assign";"hoist_drop";"min_live"]
+    then ["prune";"make_const";"const_fold";"hoist_assign";"hoist_drop";"min_live"]
     else opts in
   let optimizers = (List.map optimizer opts) @ [(as_opt_program cleanup_all)] in
   let optimizer = combine_opt optimizers in

--- a/transform.ml
+++ b/transform.ml
@@ -53,6 +53,7 @@ let as_opt_program (transform : opt_function) : opt_prog =
       let c, f = transform' func in
       (changed||c, f::functions) in
     let changed, functions = List.fold_left reduce (changed, []) prog.functions in
+    let functions = List.rev functions in
     if changed then Some { functions; main; } else None
 
 let optimistic_as_opt_function (transformation : create_optimistic_version)


### PR DESCRIPTION
Implements #73.

When reading the diff, it might be easier to ignore the deleted code in `Transform.constant_fold`, since I basically deleted everything and wrote constant folding from scratch.

I also updated the old constant propagation tests and added some new ones.

(One thing I noticed is that the other test drivers only optimize and compare the `main` function, ignoring everything else. This was because the tests were written before we had functions, and it's not a problem now because few of those tests involve functions. I fixed this for my constant propagation tests, but we might want to convert the other tests later.)

There's also a small fix: 95c8b75d43bcb41f9209f0ec5f4d67ae4ff27ab0. Due to the way the optimizer iterates over functions, the order in the optimized version would be reversed from the order in the original version. Not necessarily a bug, but it makes it easier to compare before/after optimizations.