### PR TITLE
Run examples in a shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ OCAMLBUILD=ocamlbuild -use-ocamlfind -use-menhir -no-links
 # -no-links: do not create symlink from build outputs in _build into
 #            the project directory
 
-all: tests sourir
-	rm -rf $(TEMPDIR)
+all: tests test_examples sourir
 
 tests:
 	$(OCAMLBUILD) tests.byte
@@ -24,19 +23,8 @@ runtop: lib
 run: sourir
 	./sourir examples/sum.sou
 
-TEMPDIR := $(shell mktemp -d)
-
 test_examples: sourir
-	mkdir $(TEMPDIR)/examples
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet \
-	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 0 | ./sourir $$f --quiet --opt all \
-	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet \
-	  > $(TEMPDIR)/$$f.out; done
-	for f in examples/*.sou; do yes 1 | ./sourir $$f --quiet --opt all \
-	  > $(TEMPDIR)/$$f.opt.out && diff $(TEMPDIR)/$$f.out $(TEMPDIR)/$$f.opt.out; done
-	rm -rf $(TEMPDIR)
+	bash test_examples.sh
 
 clean:
 	ocamlbuild -clean

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+SOURIR="../sourir"
+
+# Move into examples directory
+pushd examples > /dev/null 2>&1
+
+# Create a temp directory
+TEMPDIR=`mktemp -d`
+
+# Confirm that we created the directory
+if [[ ! "$TEMPDIR" || ! -d "$TEMPDIR" ]]; then
+  echo "Could not create temp dir!"
+  exit 1
+fi
+
+# Always delete temp dir and its contents
+function cleanup {
+  rm -rf "$TEMPDIR"
+  popd > /dev/null 2>&1
+}
+trap cleanup EXIT
+
+# Test file $1
+function runtest {
+  yes 0 | $SOURIR "$1" --quiet --opt all > $TEMPDIR/$1.opt.out && \
+  yes 0 | $SOURIR "$1" --quiet > $TEMPDIR/$1.out && \
+  diff $TEMPDIR/$1.out $TEMPDIR/$1.opt.out > /dev/null && \
+  yes 1 | $SOURIR "$1" --quiet --opt all > $TEMPDIR/$1.opt.out && \
+  yes 1 | $SOURIR "$1" --quiet > $TEMPDIR/$1.out && \
+  diff $TEMPDIR/$1.out $TEMPDIR/$1.opt.out > /dev/null
+}
+
+# Iterate over examples in directory
+ALL_OK=0
+for f in *.sou; do
+  runtest $f
+  if [[ $? -ne 0 ]]; then
+    echo "Example $f failed!"
+    ALL_OK=127
+  fi
+done
+
+exit $ALL_OK


### PR DESCRIPTION
Resolves #108.

Each example is tested separately, and the result is saved. If any of the tests fail, then the script returns a non-zero exit code. The script will also print the name of the failing example.

So Travis should see the failure (and the build should fail with this PR).

I also stuck `test_examples` in `make all`. This was probably why we didn't catch this error earlier.