### PR TITLE
Array by ref

### DIFF
--- a/IO.ml
+++ b/IO.ml
@@ -7,10 +7,8 @@ let rec string_of_value : value -> string = function
   | Nil -> "nil"
   | Bool b -> string_of_bool b
   | Int n -> string_of_int n
-  | Fun_ref f -> "'" ^ f
-  | Array vs ->
-    let ss = Array.to_list (Array.map string_of_value vs) in
-    "[" ^ String.concat ", " ss ^ "]"
+  | Fun_ref f -> Printf.sprintf "'%s" f
+  | Array addr -> Printf.sprintf "array@%d" (addr :> int)
 
 let value_of_string str =
   try Parse.value_of_string str

--- a/analysis.ml
+++ b/analysis.ml
@@ -106,14 +106,14 @@ let make_total result =
 let forward_analysis init_state instrs merge update =
   let successors = successors instrs in
   let starts = starts instrs in
-  assert (starts != []);
+  assert (starts <> []);
   let init = List.map (fun pos -> (init_state, pos)) starts in
   make_total (dataflow_analysis successors init instrs merge update)
 
 let backwards_analysis init_state instrs merge update =
   let predecessors = predecessors instrs in
   let exits = stops instrs @ osrs instrs in
-  assert (exits != []);
+  assert (exits <> []);
   let init = List.map (fun pos -> (init_state, pos)) exits in
   make_total (dataflow_analysis predecessors init instrs merge update)
 

--- a/analysis.ml
+++ b/analysis.ml
@@ -26,7 +26,8 @@ let successors_at (instrs : instructions) pc : pc list =
   let resolve = Instr.resolve instrs in
   let all_succ =
     match instr with
-    | Decl_const _ | Decl_mut _ | Assign _ | Array_assign _
+    | Decl_const _ | Decl_mut _ | Decl_array _
+    | Assign _ | Array_assign _
     | Drop _ | Clear _ | Read _ | Call _ | Label _
     | Comment _ | Osr _ | Print _ ->
       let is_last = pc' = Array.length instrs in

--- a/check.ml
+++ b/check.ml
@@ -88,9 +88,8 @@ let well_formed prog =
 
     let check_fun_ref instr =
       let rec check_value = function
-        | Nil | Bool _ | Int _ -> ()
+        | Nil | Bool _ | Int _ | Array _ -> ()
         | Fun_ref x -> ignore (lookup_fun x)
-        | Array vs -> Array.iter check_value vs
       in
       let check_simple_expr = function
         | Var _ -> ()
@@ -113,12 +112,14 @@ let well_formed prog =
          List.iter check_arg es)
       | Decl_const (_, e)
       | Decl_mut (_, Some e)
+      | Decl_array (_, Length e)
       | Assign (_, e)
       | Branch (e, _, _)
       | Print e
       | Stop e
-      | Return e ->
-        check_expr e
+      | Return e
+        -> check_expr e
+      | Decl_array (_, List es) -> List.iter check_expr es
       | Decl_mut (_, None)
       | Drop _ | Clear _ | Read _
       | Label _ | Goto _ | Comment _ -> ()

--- a/disasm.ml
+++ b/disasm.ml
@@ -24,11 +24,9 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
       | Op (Neq,  [a; b]) -> pr buf "(%a != %a)" simple a simple b
       | Op (Eq,   [a; b]) -> pr buf "(%a == %a)" simple a simple b
       | Op ((Plus | Neq | Eq), _)         -> assert(false)
-      | Op (Array_alloc, [size]) -> pr buf "array(%a)" simple size
-      | Op (Array_of_list, li) -> pr buf "[%a]" (dump_comma_separated simple) li
       | Op (Array_index, [array; index]) -> pr buf "%a[%a]" simple array simple index
       | Op (Array_length, [array]) -> pr buf "length(%a)" simple array
-      | Op ((Array_alloc | Array_index | Array_length), _) -> assert(false)
+      | Op ((Array_index | Array_length), _) -> assert(false)
     in
     let dump_arg buf arg =
       match arg with
@@ -46,6 +44,9 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     | Decl_const (var, exp)           -> pr buf " const %s = %a" var dump_expr exp
     | Decl_mut (var, Some exp)        -> pr buf " mut %s = %a" var dump_expr exp
     | Decl_mut (var, None)            -> pr buf " mut %s" var
+    | Decl_array (var, Length exp)    -> pr buf " array %s[%a]" var dump_expr exp
+    | Decl_array (var, List li)       -> pr buf " array %s = [%a]" var
+                                           (dump_comma_separated dump_expr) li
     | Drop var                        -> pr buf " drop %s" var
     | Clear var                       -> pr buf " clear %s" var
     | Assign (var, exp)               -> pr buf " %s <- %a" var dump_expr exp

--- a/edit.ml
+++ b/edit.ml
@@ -35,7 +35,7 @@ let move instrs from_pc to_pc =
   let (dir, to_pc) = if from_pc > to_pc then (-1, to_pc) else (1, to_pc-1) in
   let from = instrs.(from_pc) in
   let rec move pc =
-    if pc != to_pc then begin
+    if pc <> to_pc then begin
       instrs.(pc) <- instrs.(pc+dir);
       move (pc+dir)
     end
@@ -132,17 +132,17 @@ let replace_uses_in_instruction old_name new_name instr : instruction =
 
   match instr with
   | Call (x, f, exs) ->
-    assert(x != old_name);   (* -> invalid scope *)
+    assert(x <> old_name);   (* -> invalid scope *)
     Call (x, in_expression f, List.map in_arg exs)
   | Stop e ->
     Stop (in_expression e)
   | Return e ->
     Return (in_expression e)
   | Decl_const (x, exp) ->
-    assert(x != old_name);   (* -> invalid scope *)
+    assert(x <> old_name);   (* -> invalid scope *)
     Decl_const (x, in_expression exp)
   | Decl_mut (x, Some exp) ->
-    assert (x != old_name);
+    assert (x <> old_name);
     Decl_mut (x, Some (in_expression exp))
   | Assign (x, exp) ->
     Assign (x, in_expression exp)
@@ -163,7 +163,7 @@ let replace_uses_in_instruction old_name new_name instr : instruction =
     Osr {cond; target; map}
   | Decl_mut (x, None)
   | Read x ->
-    assert (x != old_name);
+    assert (x <> old_name);
     instr
 
   | Label _ | Goto _ | Comment _ ->

--- a/edit.ml
+++ b/edit.ml
@@ -144,6 +144,12 @@ let replace_uses_in_instruction old_name new_name instr : instruction =
   | Decl_mut (x, Some exp) ->
     assert (x <> old_name);
     Decl_mut (x, Some (in_expression exp))
+  | Decl_array (x, def) ->
+    assert (x <> old_name);
+    let def = match def with
+      | Length e -> Length (in_expression e)
+      | List es -> List (List.map in_expression es)
+    in Decl_array (x, def)
   | Assign (x, exp) ->
     Assign (x, in_expression exp)
   | Array_assign (x, index, exp) ->

--- a/examples/array.sou
+++ b/examples/array.sou
@@ -1,10 +1,10 @@
-const x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+array x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 const len = length(x)
-mut y = array(len)
+array y[len]
 mut i = 0
 loop:
+  print x[i]
   y[i] <- x[i]
   i <- (i + 1)
   branch (i == len) done loop
 done:
-  print y

--- a/examples/array_sum.sou
+++ b/examples/array_sum.sou
@@ -1,4 +1,4 @@
-const x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+array x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 const len = length(x)
 mut sum = 0
 mut i = 0

--- a/parser.mly
+++ b/parser.mly
@@ -128,6 +128,10 @@ instruction:
   { Decl_mut (x, None) }
 | MUT x=variable EQUAL e=expression
   { Decl_mut (x, Some e) }
+| ARRAY x=variable LBRACKET e=expression RBRACKET
+  { Decl_array (x, Length e) }
+| ARRAY x=variable EQUAL LBRACKET es=separated_list(COMMA, expression) RBRACKET
+  { Decl_array (x, List es) }
 | x=variable LEFTARROW e=expression
   { Assign (x, e) }
 | x=variable LBRACKET i=expression RBRACKET LEFTARROW e=expression
@@ -165,10 +169,6 @@ expression:
   | e = simple_expression { Simple e }
   | LPAREN e1=simple_expression op=infixop e2=simple_expression RPAREN
     { Op (op, [e1;e2]) }
-  | ARRAY LPAREN size=simple_expression RPAREN
-    { Op (Array_alloc, [size]) }
-  | LBRACKET xs=separated_list(COMMA, simple_expression) RBRACKET
-    { Op (Array_of_list, xs) }
   | x=variable LBRACKET index=simple_expression RBRACKET
     { Op (Array_index, [Var x; index]) }
   | LENGTH LPAREN x=simple_expression RPAREN
@@ -196,5 +196,4 @@ lit:
 
 value:
   | lit { $1 }
-  | LBRACKET vs=separated_list(COMMA, value) RBRACKET
-    { (Array (Array.of_list vs) : value) }
+

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 SOURIR="../sourir"
 
 # Move into examples directory

--- a/tests.ml
+++ b/tests.ml
@@ -1335,12 +1335,12 @@ let do_test_mut_to_const () =
   ();;
 
 let do_test_array () =
-  let test filename value =
-    run (Parse.program_of_file filename) no_input (trace_is [value]) () in
+  let test filename p =
+    run (Parse.program_of_file filename) no_input p () in
 
-  test "examples/array.sou" (Array [|Int 1; Int 2; Int 3; Int 4; Int 5;
-                                     Int 6; Int 7; Int 8; Int 9; Int 10|]);
-  test "examples/array_sum.sou" (Int 55);
+  test "examples/array.sou" (trace_is [Int 1; Int 2; Int 3; Int 4; Int 5;
+                                       Int 6; Int 7; Int 8; Int 9; Int 10]);
+  test "examples/array_sum.sou" (trace_is [Int 55]);
   ()
 
 let do_test_deopt () =
@@ -1475,8 +1475,8 @@ let suite =
    "parser6">:: test_parse_disasm  ("branch (x == y) as fd\n");
    "parser7">:: test_parse_disasm  ("const x = (y + x)\n x <- (x == y)\n# asdfasdf\nbranch (x == y) as fd\n");
    "parser8">:: test_parse_disasm_file "examples/sum.sou";
-   "parser_arr1">:: test_parse_disasm ("const x = array(10)\n");
-   "parser_arr2">:: test_parse_disasm ("const x = []\nconst y = [1, x, nil]\n");
+   "parser_arr1">:: test_parse_disasm ("array x[10]\n");
+   "parser_arr2">:: test_parse_disasm ("array x = []\narray x = [1, x, nil]\n");
    "parser_arr3">:: test_parse_disasm ("const x = y[10]\n");
    "parser_arr4">:: test_parse_disasm ("const x = length(y)\n");
    "parser_arr_file">:: test_parse_disasm_file "examples/array_sum.sou";

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -40,6 +40,12 @@ let const_prop ({formals; instrs} : analysis_input) : instructions option =
     | Decl_mut (y, Some e) ->
       assert (x <> y);
       Decl_mut (y, Some (replace e))
+    | Decl_array (y, def) ->
+      assert (x <> y);
+      let def = match def with
+        | Length e -> Length (replace e)
+        | List es -> List (List.map replace es)
+      in Decl_array (y, def)
     | Assign (y, e) ->
       assert (x <> y);
       Assign (y, replace e)


### PR DESCRIPTION
In preparation for the array cleanup, I started by making arrays by-reference instead of by-value. There are dedicated instructions to create arrays, as discussed in https://github.com/reactorlabs/sourir/pull/107#issuecomment-299481987.

```
array x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
const len = length(x)
array y[len]
...
```