### PR TITLE
Better constant folding

### DIFF
--- a/edit.ml
+++ b/edit.ml
@@ -204,5 +204,5 @@ let replace_var_in_arg var (exp : simple_expression) (in_arg : argument) : argum
   let replace = replace_var_in_exp var exp in
   match in_arg with
     | Arg_by_val e -> Arg_by_val (replace e)
-    | Arg_by_ref x as a -> assert (var <> x); a
+    | Arg_by_ref x as a -> a
 

--- a/examples/const_fold_test.sou
+++ b/examples/const_fold_test.sou
@@ -1,0 +1,14 @@
+  mut z
+  read z
+  branch (z==1) l1 l2
+l1:
+  const x = 2
+  print x
+  # prints 2
+  goto merge
+l2:
+  const x = 3
+  print x
+  # prints 3
+merge:
+  print x

--- a/examples/mut_const_fold_test.sou
+++ b/examples/mut_const_fold_test.sou
@@ -1,0 +1,19 @@
+  mut z
+  read z
+  mut x = 1
+  branch (z==1) l1 l2
+l1:
+  print x
+  # prints 1
+  x <- 2
+  goto merge
+l2:
+  x <- 3
+  print x
+  # prints 3
+  goto merge
+merge:
+  # it is important that the
+  # values of x are not merged here
+  print x
+

--- a/instr.ml
+++ b/instr.ml
@@ -342,7 +342,14 @@ let required_vars = function
     ) as e -> used_vars e
 
 let changed_vars = function
-  | Call (x, _, _)
+  | Call (x, _, args) ->
+    let changed_arg = function
+      | Arg_by_val _ -> ModedVarSet.empty
+      | Arg_by_ref x -> ModedVarSet.singleton (Mut_var, x)
+    in
+    ModedVarSet.empty
+    |> List.fold_right ModedVarSet.union (List.map changed_arg args)
+    |> ModedVarSet.add (Const_var, x)
   | Decl_const (x, _) -> ModedVarSet.singleton (Const_var, x)
   | Decl_mut (x, Some _)
   | Assign (x ,_)

--- a/transform.ml
+++ b/transform.ml
@@ -48,7 +48,15 @@ let as_opt_program (transform : opt_function) : opt_prog =
     | None -> false, instrs
     | Some instrs -> true, instrs in
   fun prog ->
-    let changed, main = transform' prog.main in
+    let changed, main =
+      try transform' prog.main
+      with exn ->
+        prerr_endline "Optimization Failure on the following program:";
+        let buf = Buffer.create 42 in
+        Disasm.disassemble buf prog;
+        prerr_string (Buffer.contents buf);
+        raise exn
+    in
     let reduce (changed, functions) func =
       let c, f = transform' func in
       (changed||c, f::functions) in

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -12,18 +12,8 @@ open Instr
  * used, and the declaration can be removed by running `minimize_lifetimes`.
  *)
 let const_prop ({formals; instrs} : analysis_input) : instructions option =
-  (* Finds the declarations that can be used for constant propagation.
-     Returns a list of (pc, x, l) where `const x = l` is defined at pc `pc`. *)
-  let rec find_candidates instrs pc acc =
-    if pc = Array.length instrs then acc
-    else match[@warning "-4"] instrs.(pc) with
-    | Decl_const (x, Simple(Constant(l))) ->
-        find_candidates instrs (pc+1) ((pc, x, l) :: acc)
-    | _ -> find_candidates instrs (pc+1) acc
-  in
-
   (* Replaces the variable `x` with literal `l` in instruction `instr`. *)
-  let convert x l instr =
+  let replace x l instr =
     let replace = Edit.replace_var_in_exp x l in
     let replace_arg = Edit.replace_var_in_arg x l in
     match instr with
@@ -47,10 +37,8 @@ let const_prop ({formals; instrs} : analysis_input) : instructions option =
         | List es -> List (List.map replace es)
       in Decl_array (y, def)
     | Assign (y, e) ->
-      assert (x <> y);
       Assign (y, replace e)
     | Array_assign (y, i, e) ->
-      assert (x <> y);
       Array_assign (y, replace i, replace e)
     | Branch (e, l1, l2) -> Branch (replace e, l1, l2)
     | Print e -> Print (replace e)
@@ -60,7 +48,12 @@ let const_prop ({formals; instrs} : analysis_input) : instructions option =
         match osr_def with
         | Osr_const (y, e) -> Osr_const (y, replace e)
         | Osr_mut (y, e) -> Osr_mut (y, replace e)
-        | Osr_mut_ref (y, z) -> if x=z then Osr_mut (y, Simple l) else osr_def
+        | Osr_mut_ref (_y, _z) ->
+          (* we disable replacing aliases (mut y = &z) even
+             when the value of (z) is statically known
+             as this actually pessimizes the code, adding
+             an extra allocation *)
+          osr_def
         | Osr_mut_undef y -> Osr_mut_undef y) map
       in
       let cond = List.map replace cond in
@@ -69,53 +62,92 @@ let const_prop ({formals; instrs} : analysis_input) : instructions option =
     | Drop y
     | Clear y
     | Read y ->
-      assert (x <> y);
       instr
     | Label _ | Goto _ | Comment _ -> instr in
 
-  (* Finds the target pcs to perform constant propagation. *)
-  let rec find_targets instrs x worklist acc =
-    let open Analysis in
-    match worklist with
-    | [] -> acc
-    | pc :: rest ->
-      begin match[@warning "-4"] instrs.(pc) with
-      | Drop y when x = y ->
-        (* `x` is now out of scope, but continue searching the `rest` of the
-           worklist. *)
-        find_targets instrs x rest acc
-      | instr ->
-        if PcSet.mem pc acc then
-          (* Already seen this pc, but continue searching the `rest` of the
-             worklist. *)
-          find_targets instrs x rest acc
-        else
-          (* Add the current `pc` to the accumulator and update the worklist
-             with our successors. *)
-          let succs = successors_at instrs pc in
-          find_targets instrs x (succs @ rest) (PcSet.add pc acc)
-      end
-  in
+  let module VarMap = Map.Make(Variable) in
 
-  (* Perform constant propagation. *)
-  let work instrs =
+  let module Approx = struct
+    type t = Unknown | Value of value
+    let equal a1 a2 = match a1, a2 with
+      | Unknown, Unknown -> true
+      | Unknown, Value _ | Value _, Unknown -> false
+      | Value v1, Value v2 -> Eval.value_eq v1 v2
+  end in
+
+  (* for each instruction, what is the set of variables that are constant? *)
+  let constants =
     let open Analysis in
-    (* Find all constant propagation candidates. *)
-    let candidates = find_candidates instrs 0 [] in
-    if candidates = [] then None else
-    (* Perform all propagations for a single candidate. *)
-    let propagate instrs (pc, x, l) =
-      let succs = successors_at instrs pc in
-      let targets = find_targets instrs x succs PcSet.empty in
-      let instrs = Array.copy instrs in
-      let convert_at pc = instrs.(pc) <- convert x (Constant(l)) instrs.(pc) in
-      PcSet.iter convert_at targets;
-      instrs
+    let open Approx in
+    let merge pc cur incom =
+      let merge_approx x mv1 mv2 = match mv1, mv2 with
+        | None, _ | _, None ->
+          failwith "scope error?"
+        | Some Unknown, _ | _, Some Unknown -> Some Unknown
+        | Some (Value v1), Some (Value v2) ->
+          if Eval.value_eq v1 v2 then Some (Value v1) else Some Unknown
+      in
+      if VarMap.equal Approx.equal cur incom then None
+      else Some (VarMap.merge merge_approx cur incom)
     in
-    Some (List.fold_left propagate instrs candidates)
+    let update pc cur =
+      match[@warning "-4"] instrs.(pc) with
+      | Decl_const (x, Simple (Constant l))
+      | Decl_mut (x, Some (Simple (Constant l)))
+        ->
+        VarMap.add x (Value l) cur
+      | Decl_array (x, _) ->
+        (* this case could be improved with approximation for arrays so
+           that, eg., length(x) could be constant-folded *)
+        VarMap.add x Unknown cur
+      | Decl_const (x, _) | Decl_mut (x, _) ->
+        VarMap.add x Unknown cur
+      | Call (x, _, _) as call ->
+        let mark_unknown (_, x) cur = VarMap.add x Unknown cur in
+        cur
+        |> ModedVarSet.fold mark_unknown (changed_vars call)
+        |> VarMap.add x Unknown
+      | Drop x ->
+        VarMap.remove x cur
+      | Array_assign (x, _, _) | Read x | Clear x ->
+        assert (VarMap.mem x cur);
+        (* the array case could be improved with approximation for
+           arrays *)
+        VarMap.add x Unknown cur
+      | Assign (x, Simple (Constant l)) ->
+        assert (VarMap.mem x cur);
+        VarMap.add x (Value l) cur
+      | Assign (x, _) ->
+        VarMap.add x Unknown cur
+      | ( Branch _ | Label _ | Goto _ | Return _
+        | Print _ | Stop _ | Osr _ | Comment _)
+        as instr ->
+        begin
+          assert (ModedVarSet.is_empty (changed_vars instr));
+          assert (VarSet.is_empty (dropped_vars instr));
+          assert (ModedVarSet.is_empty (defined_vars instr));
+        end;
+        cur
+    in
+    let initial_state =
+      let add_formal (_, x) st = VarMap.add x Unknown st in
+      ModedVarSet.fold add_formal formals VarMap.empty
+    in
+    Analysis.forward_analysis initial_state instrs merge update
   in
 
-  work instrs
+  let transform_instr pc instr =
+    let consts = constants pc in
+    let transform x approx instr =
+      match approx with
+      | Approx.Unknown -> instr
+      | Approx.Value l -> replace x (Constant l) instr in
+    VarMap.fold transform consts instr in
+
+  let new_instrs = Array.mapi transform_instr instrs in
+  if new_instrs = instrs
+  then None
+  else Some new_instrs
 
 open Transform_utils
 

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -136,6 +136,7 @@ let make_constant (({formals; instrs} as inp) : analysis_input) : instructions o
       in List.for_all is_passed_by_val exp
     | Decl_const (_, _)
     | Decl_mut (_, _)
+    | Decl_array _
     | Return _
     | Branch (_, _, _)
     | Label _


### PR DESCRIPTION
This patch extends constant-folding to work correctly over both `const` and `mut` binding: if an assignment is done on a mutable variable, its previous static value (if it exists) is removed from the dictionary of known approximations.

This is the patch that I had in mind when I proposed to "not change anything to the language" two Mondays ago.  By using a flow analysis in the constant folding, we can nicely handle situations a merge point has to merge environments with distinct approximations for a given variable.

I am still sentimental about moving from this nice place, but the reason I did the patch is that it's on the least-effort path towards the big simplification anyway: I started hacking on the simplification, but without this patch constant propagation completely breaks down when adding assignments to variable, and fixing the tests becomes impractical.