### PR TITLE
fix a hoist_drop bug due to a fallthrough

### DIFF
--- a/examples/regression_without_fallthrough.sou
+++ b/examples/regression_without_fallthrough.sou
@@ -1,0 +1,4 @@
+const x = 10
+label:
+drop x
+print 1


### PR DESCRIPTION
`Transform.remove_fallthroughs_to_label` has been removed by
f86504b38b6e1ff4d93a1bf0dfe194ef48f7a2e0, but I'm not sure why, it is
still necessary for examples/regression_without_fallthrough.sou to work.

Besides, in the case where there is a fallthrough, the assertion in `is_blocking`:

    let blocking = VarSet.mem var (required_vars instr) in
    let declared = VarSet.mem var (ModedVarSet.untyped (declared_vars instr)) in
    assert (blocking || not(declared));
    blocking

is violated: in the program

    var x = 10
    label:
    drop x

the instruction above the label (`var x = 10`) is not blocking
(it annihilates instead) but it is declaring `x`. I removed the
assertion -- I don't understand what it protects again, and it
caused an inconvenience while debugging this.