### PR TITLE
fix hoist_assign

### DIFF
--- a/examples/type_tests.sou
+++ b/examples/type_tests.sou
@@ -1,0 +1,15 @@
+var a = false
+var b = false
+
+branch (a == 1) $num $cont
+
+$num:
+# This assignment cannot be hoisted since it depends on the branch
+b <- (a+1)
+print b
+goto cont_
+
+$cont:
+goto cont_
+
+cont_:

--- a/examples/type_tests2.sou
+++ b/examples/type_tests2.sou
@@ -1,0 +1,21 @@
+var a = false
+var b = false
+
+print a
+
+# This assignment can be hoisted since it does not depend on the branch
+b <- (a==true)
+
+goto bb
+bb:
+
+branch (a == 1) $num $cont
+
+$num:
+print b
+goto cont_
+
+$cont:
+goto cont_
+
+cont_:

--- a/transform_utils.ml
+++ b/transform_utils.ml
@@ -42,3 +42,45 @@ let change_instrs (transform : pc -> instruction_change) ({formals; instrs} : an
         acc_instr (pc+1) (instrs.(pc)::acc) changed
   in
   acc_instr 0 [] false
+
+(* This util can fix the scope after inserting a fresh variable in the graph.
+ * As an additional sideeffect it will make every drop explicit. *)
+let fix_scope : transform_instructions = fun {formals; instrs} ->
+  let merge pc cur incom =
+    let res = VarSet.inter cur incom in
+    if VarSet.equal res cur then None else Some res
+  in
+  let update pc cur =
+    let instr = instrs.(pc) in
+    let added = Instr.declared_vars instr in
+    let updated = VarSet.union cur added in
+    let dropped = Instr.dropped_vars instr in
+    VarSet.diff updated dropped
+  in
+  let initial_state = formals in
+  let scope = Analysis.forward_analysis initial_state instrs merge update in
+  let succs = Analysis.successors instrs in
+  let transform pc =
+    let succs = succs.(pc) in
+    assert(List.length succs <= 2);
+    let my_scope = scope pc in
+    let succ_scopes = List.map (fun pc -> scope pc) succs in
+    let min_scope = List.fold_left VarSet.union VarSet.empty succ_scopes in
+    (* Because of split edge all the succs should agree on one scope *)
+    assert (succs = [] || VarSet.equal (List.hd succ_scopes) min_scope);
+
+    let to_drop = VarSet.diff my_scope min_scope in
+    let to_drop = VarSet.diff to_drop (dropped_vars instrs.(pc)) in
+    let to_drop_instrs = List.map (fun var -> Drop var) (VarSet.elements to_drop) in
+
+    match[@warning "-4"] instrs.(pc) with
+    | Stop _
+    | Goto _
+    | Branch _
+    | Return _ ->
+        (* Don't insert drops after the last instruction *)
+      InsertBefore to_drop_instrs
+    | _ ->
+      InsertAfter to_drop_instrs
+  in
+  change_instrs transform {formals;instrs}


### PR DESCRIPTION
There where two things broken with the pass:

1. It might hoist assignments to a place where the rhs expression is invalid
2. It might destroy the scope

The first problem occurs for example in:

     var a = true
     branch (a==1) isint cont
    isint:
     a <- a+2
    cont:

If we hoist the assignment to line 2 the addition throws
a type error. The problem is solved by only hoisting assignments
with simple expressions rhs. A better approach would be nice...

The second problem arises for example in:

     branch ... a b
    a:
     var a = 1
     ...
     a <- 2
     ...
     drop a
     goto b

If we create a new variable a_1 inside the branch we need to
drop it before merging the scope with b. This problem is solved
by running a generic fix_scope pass which makes all missing drops
explicit.