### PR TITLE
Fix hoist drop

### DIFF
--- a/examples/scope_err.sou
+++ b/examples/scope_err.sou
@@ -1,0 +1,13 @@
+function main()
+stop 0
+
+function obj_check (var obj, var tpe)
+    var candidate
+    branch (obj == nil) error l1
+  l1:
+    candidate <- obj[0]
+    branch (candidate != tpe) error done
+  done:
+    return true
+  error:
+    return false

--- a/examples/type_tests.sou
+++ b/examples/type_tests.sou
@@ -1,0 +1,11 @@
+var a = false
+var b = false
+
+branch (a == 1) num cont
+
+num:
+# This assignment cannot be hoisted since it depends on the branch
+b <- (a+1)
+print b
+
+cont:

--- a/examples/type_tests2.sou
+++ b/examples/type_tests2.sou
@@ -1,0 +1,17 @@
+var a = false
+var b = false
+
+print a
+
+# This assignment can be hoisted since it does not depend on the branch
+b <- (a==true)
+
+goto bb
+bb:
+
+branch (a == 1) num cont
+
+num:
+print b
+
+cont:

--- a/tests.ml
+++ b/tests.ml
@@ -573,9 +573,11 @@ let do_test_codemotion = function () ->
   " in
   let expected = parse "
        goto bla
+      loop_1:
+       goto loop
       loop:
        x <- (x + y_1)
-       branch (x == 10) end loop
+       branch (x == 10) end loop_1
       end:
        drop x
        drop y
@@ -606,9 +608,12 @@ let do_test_codemotion = function () ->
        var y_1 = 1
        var x = 1
        var y = 2
+       goto loop
+      loop_1:
+       goto loop
       loop:
        x <- (x + y_1)
-       branch (x == 10) end loop
+       branch (x == 10) end loop_1
       end:
        drop x
        drop y
@@ -637,7 +642,7 @@ let do_test_codemotion = function () ->
   let expected = parse "
        var a = 1
        var b = 2
-       branch (a==b) ba bb
+       branch (a==b) ba bb_2
       ba:
        var d = 1
        var d_1 = d
@@ -652,6 +657,8 @@ let do_test_codemotion = function () ->
       bb_1:
        drop d
        drop d_1
+       goto bb
+      bb_2:
        goto bb
       bb:
        drop a
@@ -680,7 +687,7 @@ let do_test_codemotion = function () ->
   let expected = parse "
        var a = 1
        var b = 2
-       branch (a==b) ba bb
+       branch (a==b) ba bb_3
       ba:
        var d = 1
        var d_1 = d
@@ -697,6 +704,8 @@ let do_test_codemotion = function () ->
       bb_2:
        drop d
        drop d_1
+       goto bb
+      bb_3:
        goto bb
       bb:
        drop a
@@ -767,12 +776,16 @@ let do_test_minimize_lifetime = function () ->
   let expected = parse "
        var a = 12
        var b = false
-       branch b o1 o2
+       branch b o1 o2_1
       o1:
        a <- 1
        print a
-      o2:
        drop a
+       goto o2
+      o2_1:
+       drop a
+       goto o2
+      o2:
        print b
        drop b
        goto x
@@ -1158,25 +1171,6 @@ let do_test_push_drop () =
   test t 5 t;
   let t = parse "
     var x = 1
-    branch (1==1) l1 l2
-   l1:
-    goto l2
-   l2:
-    drop x
-    " in
-  let e = parse "
-    var x = 1
-    branch (1 == 1) l1 l2_1
-   l1:
-    goto l2
-   l2_1:
-    goto l2
-   l2:
-    drop x
-   " in
-  test t 5 e;
-  let t = parse "
-    var x = 1
     branch (1==1) e1 e2
    e1:
     goto l
@@ -1272,47 +1266,6 @@ let do_test_drop_driver () =
     drop x
     print 2
     stop 0
-  |expect};
-  test "x" {given|
-    var x = 1
-    branch (1 == 1) la lb
-   la:
-    branch (1 == 1) l1 l2
-   lb:
-    branch (2 == 2) l2 l3
-   l1:
-    print 1
-    goto die_ende
-   l2:
-    print 2
-    goto die_ende
-   l3:
-    print 3
-    goto die_ende
-  die_ende:
-    drop x
-    stop 0
-  |given} {expect|
-     branch (1 == 1) la lb
-    la:
-     branch (1 == 1) l1 l2_2
-    lb:
-     branch (2 == 2) l2_1 l3
-    l1:
-     print 1
-     goto die_ende
-    l2_1:
-     goto l2
-    l2_2:
-     goto l2
-    l2:
-     print 2
-     goto die_ende
-    l3:
-     print 3
-     goto die_ende
-    die_ende:
-     stop 0
   |expect};
   ()
 

--- a/transform_hoist.ml
+++ b/transform_hoist.ml
@@ -178,7 +178,6 @@ module Drop = struct
   let is_eliminating var instr =
     match[@warning "-4"] instr with
     | Assign (x, _) -> x = var
-    | Array_assign (x, _, _) -> x = var
     | _ -> false
 
   let is_annihilating var instr =

--- a/transform_utils.ml
+++ b/transform_utils.ml
@@ -19,6 +19,7 @@ let change_instrs (transform : pc -> instruction_change) ({formals; instrs} : an
       | Replace is ->
         acc_instr (pc+1) (List.rev_append is acc) true
       | Insert is ->
+        assert(match[@warning "-4"] instrs.(pc) with | Label _ -> false | _ -> true);
         acc_instr (pc+1) (instrs.(pc) :: List.rev_append is acc) true
       | InsertAfter is ->
         acc_instr (pc+1) (List.rev_append is (instrs.(pc) :: acc)) true
@@ -26,3 +27,68 @@ let change_instrs (transform : pc -> instruction_change) ({formals; instrs} : an
         acc_instr (pc+1) (instrs.(pc)::acc) changed
   in
   acc_instr 0 [] false
+
+
+(* Splits all edges that have multi-predecessors branching *)
+let normalize_graph instrs =
+  let rec normalize instrs preds pc =
+    let is_branch pred_pc = match[@warning "-4"] instrs.(pred_pc) with
+    | Branch _ -> true
+    | _ -> false in
+    if pc = Array.length instrs then instrs
+    else match[@warning "-4"] instrs.(pc) with
+      | Label l ->
+          let branches = List.filter (fun p ->
+            is_branch p) preds.(pc) in
+          if List.length branches < 2 then normalize instrs preds (pc+1)
+          else begin
+            let branch_pc = List.hd branches in
+            let fixed, _ = Edit.split_edge instrs preds branch_pc l pc in
+            normalize fixed (Analysis.predecessors fixed) 0
+          end
+      | _ -> normalize instrs preds (pc+1)
+  in
+  normalize instrs (Analysis.predecessors instrs) 0
+
+(* This util can fix the scope after inserting a fresh variable in the graph.
+ * As an additional sideeffect it will make every drop explicit. *)
+let fix_scope : transform_instructions = fun {formals; instrs} ->
+  let instrs = normalize_graph instrs in
+  let merge pc cur incom =
+    let res = VarSet.inter cur incom in
+    if VarSet.equal res cur then None else Some res
+  in
+  let update pc cur =
+    let instr = instrs.(pc) in
+    let added = Instr.declared_vars instr in
+    let updated = VarSet.union cur added in
+    let dropped = Instr.dropped_vars instr in
+    VarSet.diff updated dropped
+  in
+  let initial_state = formals in
+  let scope = Analysis.forward_analysis initial_state instrs merge update in
+  let succs = Analysis.successors instrs in
+  let transform pc =
+    let succs = succs.(pc) in
+    assert(List.length succs <= 2);
+    let my_scope = scope pc in
+    let succ_scopes = List.map (fun pc -> scope pc) succs in
+    let min_scope = List.fold_left VarSet.union VarSet.empty succ_scopes in
+    (* Because of split edge all the succs should agree on one scope *)
+    assert (succs = [] || VarSet.equal (List.hd succ_scopes) min_scope);
+
+    let to_drop = VarSet.diff my_scope min_scope in
+    let to_drop = VarSet.diff to_drop (dropped_vars instrs.(pc)) in
+    let to_drop_instrs = List.map (fun var -> Drop var) (VarSet.elements to_drop) in
+
+    match[@warning "-4"] instrs.(pc) with
+    | Stop _
+    | Goto _
+    | Branch _
+    | Return _ ->
+        (* Don't insert drops after the last instruction *)
+      Insert to_drop_instrs
+    | _ ->
+      InsertAfter to_drop_instrs
+  in
+  change_instrs transform {formals;instrs}


### PR DESCRIPTION
Hoist drop was broken in the case from examples/scope_err.sou

It was assumed that a split edge is only necessary if the first label
to encounter sees two branches and otherwise a pull is ok.

But e.g. in the case:

        a    b

       /  \  /

      c    d

we would happily assume at `d` that the graph is in split-edge form
(because only one branch is a successor). Then we would pull on `a`
and if that succeeds the push to `b` gets lost.

The workaround is to more strongly normalize the graph, ie. allow
mergeing control flow only through gotos. This fixes the missing push
problem. Secondly split edge is performed ahead of time to avoid having
to do non-local checks for all successors of predecessors of a label.