### PR TITLE
update the scope definition

### DIFF
--- a/examples/const_fold_test.sou
+++ b/examples/const_fold_test.sou
@@ -1,13 +1,14 @@
   var z
   read z
+  var x
   branch (z==1) l1 l2
 l1:
-  var x = 2
+  x <- 2
   print x
   # prints 2
   goto merge
 l2:
-  var x = 3
+  x <- 3
   print x
   # prints 3
 merge:

--- a/scope.ml
+++ b/scope.ml
@@ -43,15 +43,15 @@ let infer ({formals; instrs} : analysis_input) : inferred_scope array =
     in
     let update pc cur =
       let instr = instructions.(pc) in
-      let declared = Instr.declared_vars instr in
-      let declared' = VarSet.elements declared in
-      let declared' = List.map (fun v -> (v, pc)) declared' in
-      let declared' = DeclSet.of_list declared' in
+      let declared_vars = Instr.declared_vars instr in
+      let decls = VarSet.elements declared_vars
+                |> List.map (fun v -> (v, pc))
+                |> DeclSet.of_list in
       let info = cur.info in
-      let shadowed = VarSet.inter (decl_as_var_set info) declared in
+      let shadowed = VarSet.inter (decl_as_var_set info) declared_vars in
       if not (VarSet.is_empty shadowed) then
         raise (DuplicateVariable (shadowed, pc));
-      let updated = DeclSet.union info declared' in
+      let updated = DeclSet.union info decls in
       let dropped = VarSet.elements (Instr.dropped_vars instr) in
       let remove set el = DeclSet.filter (fun (v, _) -> v <> el) set in
       let final_info = List.fold_left remove updated dropped in

--- a/scope.ml
+++ b/scope.ml
@@ -9,7 +9,19 @@ exception UndeclaredVariable of VarSet.t * pc
 exception ExtraneousVariable of VarSet.t * pc
 exception DuplicateVariable of VarSet.t * pc
 
-type scope_info = VarSet.t
+module Declaration = struct
+  type t = string * pc
+  let compare a b =
+    if fst a = fst b then
+      Pervasives.compare (snd a) (snd b)
+    else
+      String.compare (fst a) (fst b)
+end
+module DeclSet = Set.Make(Declaration)
+let decl_as_var_set set =
+  VarSet.of_list (fst (List.split (DeclSet.elements set)))
+
+type scope_info = DeclSet.t
 
 module PcSet = Set.Make(Pc)
 type inference_state = {
@@ -24,24 +36,29 @@ let infer ({formals; instrs} : analysis_input) : inferred_scope array =
 
   let infer_scope instructions =
     let merge pc cur incom =
-      if not (VarSet.equal cur.info incom.info)
+      if not (DeclSet.equal cur.info incom.info)
       then raise (IncompatibleScope (cur, incom, pc))
       else if PcSet.equal cur.sources incom.sources then None
       else Some { info = cur.info; sources = PcSet.union cur.sources incom.sources }
     in
     let update pc cur =
       let instr = instructions.(pc) in
-      let added = Instr.declared_vars instr in
+      let declared = Instr.declared_vars instr in
+      let declared' = VarSet.elements declared in
+      let declared' = List.map (fun v -> (v, pc)) declared' in
+      let declared' = DeclSet.of_list declared' in
       let info = cur.info in
-      let shadowed = VarSet.inter info added in
+      let shadowed = VarSet.inter (decl_as_var_set info) declared in
       if not (VarSet.is_empty shadowed) then
         raise (DuplicateVariable (shadowed, pc));
-      let updated = VarSet.union info added in
-      let dropped = Instr.dropped_vars instr in
-      let final_info = VarSet.diff updated dropped in
+      let updated = DeclSet.union info declared' in
+      let dropped = VarSet.elements (Instr.dropped_vars instr) in
+      let remove set el = DeclSet.filter (fun (v, _) -> v <> el) set in
+      let final_info = List.fold_left remove updated dropped in
       { sources = PcSet.singleton pc; info = final_info; }
     in
-    let initial_state = { sources = PcSet.empty; info = formals; } in
+    let initial = List.map (fun var -> (var, -1)) (VarSet.elements formals) in
+    let initial_state = { sources = PcSet.empty; info = DeclSet.of_list initial; } in
     let res = Analysis.forward_analysis initial_state instrs merge update in
     fun pc -> (res pc).info in
 
@@ -51,6 +68,7 @@ let infer ({formals; instrs} : analysis_input) : inferred_scope array =
     match inferred pc with
     | exception Analysis.UnreachableCode _ -> DeadScope
     | declared ->
+      let declared = decl_as_var_set declared in
       let required = Instr.required_vars instr in
       if not (VarSet.subset required declared)
       then raise (UndeclaredVariable (VarSet.diff required declared, pc));
@@ -124,15 +142,15 @@ let explain_incompatible_scope outchan s1 s2 pc =
   in
   let print_vars buf vars =
     let print_var buf var =
-      Printf.bprintf buf "var %s" var in
-    let vars = VarSet.elements vars |> Array.of_list in
+      Printf.bprintf buf "var %s(%d)" (fst var) (snd var) in
+    let vars = DeclSet.elements vars |> Array.of_list in
     Printf.bprintf buf "{";
     print_sep buf print_var vars ", " ", ";
     Printf.bprintf buf "}";
   in
   let print_only buf name1 diff name2 =
     let print_diff diff =
-      if not (VarSet.is_empty diff) then
+      if not (DeclSet.is_empty diff) then
         Printf.bprintf buf
           "  - the %s declares %a and the %s does not\n"
           name1 print_vars diff name2 in
@@ -146,8 +164,8 @@ let explain_incompatible_scope outchan s1 s2 pc =
     pc
     print_sources s1.sources
     print_sources s2.sources;
-  print_only buf "former" (VarSet.diff s1.info s2.info) "latter";
-  print_only buf "latter" (VarSet.diff s2.info s1.info) "former";
+  print_only buf "former" (DeclSet.diff s1.info s2.info) "latter";
+  print_only buf "latter" (DeclSet.diff s2.info s1.info) "former";
   Buffer.output_buffer outchan buf
 
 let report_error program = function

--- a/tests.ml
+++ b/tests.ml
@@ -227,15 +227,16 @@ z <- (x == y)
 
 let test_scope_1 test_var1 test_var2 = parse (
 " var t = false
+  var c
   branch t a b
 a:
   var a = 0
-  var c = 0
+  c <- 0
   drop a
   goto cont
 b:
   var b = 0
-  var c = 0
+  c <- 0
   drop b
 cont:
   var res = (" ^ test_var1 ^ " + " ^ test_var2 ^ ")
@@ -1516,9 +1517,9 @@ let suite =
    "scope1ok">:: run (test_scope_1 "c" "c") no_input
      (has_var "c" (Value.int 0));
    "scope1broken">:: infer_broken_scope
-     (test_scope_1 "a" "c") (undeclared ["a"] 12);
+     (test_scope_1 "a" "c") (undeclared ["a"] 13);
    "scope1broken2">:: infer_broken_scope
-     (test_scope_1 "a" "b") (undeclared ["b"; "a"] 12);
+     (test_scope_1 "a" "b") (undeclared ["b"; "a"] 13);
    "parser">:: test_parse_disasm   ("stop 0\n");
    "parser1">:: test_parse_disasm  ("var x = 3\nprint x\nstop 0\n");
    "parser2">:: test_parse_disasm  ("goto l\nx <- 3\nl:\n");


### PR DESCRIPTION
as recently discussed it is no longer considered valid if a variable
has two declaration.

This change updates the scope checker to reflect this decision.