### PR TITLE
combine checkpoint label with osr instruction

### DIFF
--- a/check.ml
+++ b/check.ml
@@ -125,7 +125,7 @@ let well_formed prog =
          * are compatible with the formals *)
         let func = lookup_fun func in
         let vers = lookup_version func version in
-        let _ = Instr.resolve vers.instrs label in
+        let _ = Instr.resolve_osr vers.instrs label in
         check_fun_ref instr
       | _ -> check_fun_ref instr
     in

--- a/disasm.ml
+++ b/disasm.ml
@@ -64,13 +64,14 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     | Print exp                       -> pr buf " print %a" dump_expr exp
     | Assert exp                      -> pr buf " assert %a" dump_expr exp
     | Read var                        -> pr buf " read %s" var
-    | Osr {cond; target = {func; version; pos=label}; map} ->
+    | Osr {label; cond; target = {func; version; pos}; map} ->
       let dump_var buf = function
         | Osr_var (x, e)     -> pr buf "var %s = %a" x dump_expr e
       in
-      pr buf " osr [%a] (%s, %s, %s) [%a]"
+      pr buf " osr %s [%a] (%s, %s, %s) [%a]"
+        label
         (dump_comma_separated dump_expr) cond
-        func version label
+        func version pos
         (dump_comma_separated dump_var) map
     | Comment str                     -> pr buf " #%s" str
     end;

--- a/edit.ml
+++ b/edit.ml
@@ -72,7 +72,6 @@ let subst_many instrs substs =
     to a [Label label] instruction in [pc'].
 *)
 let split_edge instrs preds pc label pc' =
-  assert (not (is_checkpoint_label label));
   assert (instrs.(pc') = Label label);
   let split_label = fresh_label instrs label in
   let add_split_edge =

--- a/eval.ml
+++ b/eval.ml
@@ -248,6 +248,7 @@ let instruction conf =
 let reduce conf =
   let eval conf e = eval conf.heap conf.env e in
   let resolve instrs label = Instr.resolve instrs label in
+  let resolve_osr instrs label = Instr.resolve_osr instrs label in
   let pc' = conf.pc + 1 in
   assert (conf.status = Running);
 
@@ -382,7 +383,7 @@ let reduce conf =
       let version = Instr.get_version func version in
       let instrs = version.instrs in
       { conf with
-        pc = resolve instrs label;
+        pc = resolve_osr instrs label;
         env = osr_env;
         heap = heap';
         instrs = instrs;

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -11,7 +11,7 @@ version active
  var x = 30
  var z = 0
  read z
- osr [(z == zero)] (main,old,l1) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
+ osr deopt [(z == zero)] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)
@@ -33,6 +33,7 @@ version old
  var x = 30
  var z = 0
  read z
+ osr deopt [] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  branch (z == zero) l1 l2
 l1:
  x <- (x + one)

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 126.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 125.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 124.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,9 +43,9 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: VAR IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 32.
 ##
-## instruction -> VAR variable EQUAL . expression [ NEWLINE ]
+## var_def -> VAR variable EQUAL . expression [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR variable EQUAL 
@@ -57,9 +57,10 @@ example "(x + 1)", is now expected to construct a variable declaration
 
 program: VAR IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 31.
 ##
-## instruction -> VAR variable . EQUAL expression [ NEWLINE ]
+## var_def -> VAR variable . EQUAL expression [ RBRACKET NEWLINE COMMA ]
+## var_def -> VAR variable . [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR variable 
@@ -71,9 +72,10 @@ Parsing an instruction, we parsed "var <var>" so far; the equal sign
 
 program: VAR TRIPLE_DOT 
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 30.
 ##
-## instruction -> VAR . variable EQUAL expression [ NEWLINE ]
+## var_def -> VAR . variable EQUAL expression [ RBRACKET NEWLINE COMMA ]
+## var_def -> VAR . variable [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR 
@@ -85,7 +87,7 @@ example "x", is now expected to construct a variable declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 107.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +101,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 140.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,10 +115,10 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 106.
 ##
 ## label -> IDENTIFIER . [ COLON ]
-## variable -> IDENTIFIER . [ LEFTARROW ]
+## variable -> IDENTIFIER . [ LEFTARROW LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENTIFIER 
@@ -126,93 +128,93 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 - if this is a label declaration, we expect a semicolon: "<label>:"
 - if this is an assignment, we expect a left arrow: "<var> <- <expression>"
 
-program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 95.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET 
 ##
 
 There was an error parsing the specification of the new environment of an
 osr instruction. The specification is a comma-separated list of terms of the form
 "const x = e" (where "e" is an expression), "mut x = e", "mut x = &y"
 or just "mut x". For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 94.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
 ##
 
 After "osr [...] (...) " we expect the specification of the new environment.
 It is a square bracket enclosed, comma-separated list
 of terms of the form "const x = e" (where "e" is an expression),
 "mut x = e", "mut x = &y" or just "mut x". For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 
-program: OSR LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 88.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
 ##
 
 Parsing an osr instruction, there is an error with the syntax of the target
 location "(function, version, label)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET NIL RBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 87.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
 ##
 
-Parsing an osr instruction, we parsed "osr [<expr> ...]", and are
+Parsing an osr instruction, we parsed "osr l [<expr> ...]", and are
 now expecting a target location "(function, version, label)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 84.
 ##
-## instruction -> OSR LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET 
+## OSR label LBRACKET 
 ##
 
 Parsing an osr instruction, there was an error parsing the list of conditions.
 Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 
 program: OSR TRIPLE_DOT 
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 81.
 ##
-## instruction -> OSR . LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR . label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR 
@@ -220,9 +222,9 @@ program: OSR TRIPLE_DOT
 
 Parsing an osr instruction, we parsed "osr", and are now expecting a bracket
 enclosed list of conditions. Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 program: LBRACE IDENTIFIER COMMA STOP 
 ##
@@ -263,7 +265,7 @@ program: LBRACE STOP
 ##
 ## Ends in an error in state: 5.
 ##
-## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE 
@@ -280,7 +282,7 @@ program: LBRACE TRIPLE_DOT RBRACE BOOL
 ##
 ## Ends in an error in state: 12.
 ##
-## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope RBRACE 
@@ -293,7 +295,7 @@ program: LBRACE TRIPLE_DOT TRIPLE_DOT
 ##
 ## Ends in an error in state: 11.
 ##
-## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope 
@@ -304,7 +306,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 57.
 ##
 ## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -317,7 +319,7 @@ a closing parenthesis ")" is now expected.
 
 program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 56.
 ##
 ## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -331,7 +333,7 @@ Parsing an expression, we parsed "( <arg> <op>" so far; an argument
 
 program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 42.
 ##
 ## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -348,6 +350,7 @@ program: PRINT LPAREN TRIPLE_DOT
 ## Ends in an error in state: 36.
 ##
 ## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN . prefixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN 
@@ -359,7 +362,7 @@ literal value) is now expected to construct an expression
 
 program: PRINT TRIPLE_DOT 
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 79.
 ##
 ## instruction -> PRINT . expression [ NEWLINE ]
 ##
@@ -374,7 +377,7 @@ to construct a print instruction
 
 program: READ TRIPLE_DOT 
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 77.
 ##
 ## instruction -> READ . variable [ NEWLINE ]
 ##
@@ -390,9 +393,9 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 151.
 ##
-## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP VAR COMMENT CLEAR CALL BRANCH ]
+## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction NEWLINE 
@@ -403,9 +406,9 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 150.
 ##
-## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP VAR COMMENT CLEAR CALL BRANCH ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction 

--- a/parser.mly
+++ b/parser.mly
@@ -140,10 +140,11 @@ instruction:
 | ASSERT e=expression
   { Assert e }
 | OSR
+  label=label
   LBRACKET cond=separated_list(COMMA, expression) RBRACKET
   LPAREN func=label COMMA version=label COMMA pos=label RPAREN
   LBRACKET map=separated_list(COMMA, osr_def) RBRACKET
-  { Osr {cond; target= {func; version; pos}; map} }
+  { Osr {label; cond; target= {func; version; pos}; map} }
 | STOP e=expression
   { Stop e }
 | s=COMMENT

--- a/transform.ml
+++ b/transform.ml
@@ -134,7 +134,6 @@ let optimize (opts : string list) (prog : program) : program option =
         (as_opt_program (as_opt_function Transform_assumption.hoist_assumption));
         optimizer;
         (as_opt_program (as_opt_function Transform_assumption.remove_empty_osr));
-        (as_opt_program Transform_assumption.remove_checkpoint_labels);
         optimizer_classic;
       ]
     else optimizer

--- a/transform_cleanup.ml
+++ b/transform_cleanup.ml
@@ -9,11 +9,9 @@ let remove_jmp : transform_instructions = fun ({instrs; _} as inp) ->
     if (pc+1) = Array.length instrs then Unchanged else
     match[@warning "-4"] instrs.(pc), instrs.(pc+1) with
     | Goto l1, Label l2 when l1 = l2 && pred.(pc+1) = [pc] ->
-      Remove (if is_checkpoint_label l1 then 1 else 2)
+      Remove 2
     | Label l, _ when
-        pred.(pc) = [pc-1] &&
-        succ.(pc-1) = [pc] &&
-        not (is_checkpoint_label l) ->
+        pred.(pc) = [pc-1] && succ.(pc-1) = [pc] ->
         (* A label is unused if the previous instruction is the only predecessor
          * unless the previous instruction jumps to it. The later can happen
          * if its a goto (then we already remove it -- see above) or if its a branch (which


### PR DESCRIPTION
Checkpoint labels are a bit of a hassle when it comes to transformations.
They have to be threated differently from the other labels. For example
they have to be preserved even if there is no goto/branch using them.

Also if we want to enforce some structure on the cfg in the future they
will present an exception again.

Therefore I combined them into the osr instruction.