### PR TITLE
Graph discipline2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OCAMLBUILD=ocamlbuild
+OCAMLBUILD=ocamlbuild -cflag -g
 
 # use the ocamlfind library manager
 OCAMLBUILD+= -use-ocamlfind

--- a/analysis.ml
+++ b/analysis.ml
@@ -35,8 +35,9 @@ let successors_at (instrs : instructions) pc : pc list =
       if is_last then [] else [pc']
     (* those are the instructions which manipulate controlflow:  *)
     | Stop _ | Return _ -> []
-    | Goto l -> [resolve l]
-    | Branch (_e, l1, l2) -> [resolve l1; resolve l2]
+    | Goto l -> [resolve (MergeLabel l)]
+    | Branch (_e, l1, l2) ->
+        [resolve (BranchLabel l1); resolve (BranchLabel l2)]
   in
   PcSet.elements (PcSet.of_list all_succ)
 

--- a/check.ml
+++ b/check.ml
@@ -125,7 +125,7 @@ let well_formed prog =
          * are compatible with the formals *)
         let func = lookup_fun func in
         let vers = lookup_version func version in
-        let _ = Instr.resolve vers.instrs label in
+        let _ = Instr.resolve_osr vers.instrs label in
         check_fun_ref instr
       | _ -> check_fun_ref instr
     in

--- a/disasm.ml
+++ b/disasm.ml
@@ -58,8 +58,9 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     | Drop var                        -> pr buf " drop %s" var
     | Assign (var, exp)               -> pr buf " %s <- %a" var dump_expr exp
     | Array_assign (var, index, exp)  -> pr buf " %s[%a] <- %a" var dump_expr index dump_expr exp
-    | Branch (exp, l1, l2)            -> pr buf " branch %a %s %s" dump_expr exp l1 l2
-    | Label label                     -> pr buf "%s:" label
+    | Branch (exp, l1, l2)            -> pr buf " branch %a $%s $%s" dump_expr exp l1 l2
+    | Label (MergeLabel label)        -> pr buf "%s:" label
+    | Label (BranchLabel label)        -> pr buf "$%s:" label
     | Goto label                      -> pr buf " goto %s" label
     | Print exp                       -> pr buf " print %a" dump_expr exp
     | Assert exp                      -> pr buf " assert %a" dump_expr exp

--- a/disasm.ml
+++ b/disasm.ml
@@ -64,13 +64,14 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     | Print exp                       -> pr buf " print %a" dump_expr exp
     | Assert exp                      -> pr buf " assert %a" dump_expr exp
     | Read var                        -> pr buf " read %s" var
-    | Osr {cond; target = {func; version; pos=label}; map} ->
+    | Osr {label; cond; target = {func; version; pos}; map} ->
       let dump_var buf = function
         | Osr_var (x, e)     -> pr buf "var %s = %a" x dump_expr e
       in
-      pr buf " osr [%a] (%s, %s, %s) [%a]"
+      pr buf " osr %s [%a] (%s, %s, %s) [%a]"
+        label
         (dump_comma_separated dump_expr) cond
-        func version label
+        func version pos
         (dump_comma_separated dump_var) map
     | Comment str                     -> pr buf " #%s" str
     end;

--- a/edit.ml
+++ b/edit.ml
@@ -72,7 +72,6 @@ let subst_many instrs substs =
     to a [Label label] instruction in [pc'].
 *)
 let split_edge instrs preds pc label pc' =
-  assert (not (is_checkpoint_label label));
   assert (instrs.(pc') = Label label);
   let split_label = fresh_label instrs label in
   let add_split_edge =

--- a/eval.ml
+++ b/eval.ml
@@ -248,6 +248,7 @@ let instruction conf =
 let reduce conf =
   let eval conf e = eval conf.heap conf.env e in
   let resolve instrs label = Instr.resolve instrs label in
+  let resolve_osr instrs label = Instr.resolve_osr instrs label in
   let pc' = conf.pc + 1 in
   assert (conf.status = Running);
 
@@ -382,7 +383,7 @@ let reduce conf =
       let version = Instr.get_version func version in
       let instrs = version.instrs in
       { conf with
-        pc = resolve instrs label;
+        pc = resolve_osr instrs label;
         env = osr_env;
         heap = heap';
         instrs = instrs;

--- a/eval.ml
+++ b/eval.ml
@@ -236,6 +236,7 @@ let rec eval heap env = function
 
 exception InvalidArgument
 exception InvalidNumArgs
+exception LabelFallthrough of label_type
 
 let instruction conf =
   let default_exit = (Simple (Constant (Int 0))) in
@@ -346,9 +347,9 @@ let reduce conf =
     }
   | Branch (e, l1, l2) ->
      let b = get_bool (eval conf e) in
-     { conf with pc = resolve conf.instrs (if b then l1 else l2) }
-  | Label _ -> { conf with pc = pc' }
-  | Goto label -> { conf with pc = resolve conf.instrs label }
+     { conf with pc = 1 + (resolve conf.instrs (if b then (BranchLabel l1) else (BranchLabel l2))) }
+  | Label l -> raise (LabelFallthrough l)
+  | Goto label -> { conf with pc = 1 + (resolve conf.instrs (MergeLabel label)) }
   | Read x ->
     let (IO.Next (v, input')) = conf.input () in
     let heap, env = update conf.heap conf.env x v in

--- a/examples/array.sou
+++ b/examples/array.sou
@@ -3,9 +3,12 @@ array x = [1, 2, 3, 4, five, 6, 7, 8, 9, 10]
 var len = length(x)
 array y[len]
 var i = 0
-loop:
+goto loop_body
+$loop:
+goto loop_body
+loop_body:
   print x[i]
   y[i] <- x[i]
   i <- (i + 1)
-  branch (i == len) done loop
-done:
+  branch (i == len) $done $loop
+$done:

--- a/examples/array_sum.sou
+++ b/examples/array_sum.sou
@@ -2,12 +2,15 @@ array x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 var len = length(x)
 var sum = 0
 var i = 0
-loop:
+goto loop_body
+$loop:
+  goto loop_body
+loop_body:
   var val = x[i]
   sum <- (sum + val)
   i <- (i + 1)
   drop val
-  branch (i == len) done loop
-done:
+  branch (i == len) $done $loop
+$done:
   assert (sum == 55)
   print sum

--- a/examples/cf_01_after.sou
+++ b/examples/cf_01_after.sou
@@ -1,10 +1,10 @@
   var c = 5
-  branch true l1 l2
-l1:
+  branch true $l1 $l2
+$l1:
   c <- 4
   print 1
   goto fin
-l2:
+$l2:
   c <- 5
   print 2
   goto fin

--- a/examples/cf_01_before.sou
+++ b/examples/cf_01_before.sou
@@ -5,12 +5,12 @@
   var c = (cc + 0)
   c <- (a + b)
   var d = true
-  branch d l1 l2
-l1:
+  branch d $l1 $l2
+$l1:
   c <- (c + a)
   print a
   goto fin
-l2:
+$l2:
   c <- (c + b)
   print b
   goto fin

--- a/examples/cf_02_after.sou
+++ b/examples/cf_02_after.sou
@@ -1,11 +1,13 @@
   goto bla
-loop:
+$loop:
+  goto loop_entry
+loop_entry:
   x <- (x + 1)
-  branch (x==10) end loop
-end:
+  branch (x==10) $end $loop
+$end:
   print 1
   stop 0
 bla:
   var x = 1
-  goto loop
+  goto loop_entry
 

--- a/examples/cf_02_before.sou
+++ b/examples/cf_02_before.sou
@@ -1,10 +1,12 @@
   var n = 10
   goto bla
-loop:
+$loop:
+  goto loop_body
+  loop_body:
   y <- z
   x <- (x + z)
-  branch (x==n) end loop
-end:
+  branch (x==n) $end $loop
+$end:
   print z
   stop 0
 bla:
@@ -12,5 +14,5 @@ bla:
   var zz = z
   var x = 1
   var y = (zz + 0)
-  goto loop
+  goto loop_body
 

--- a/examples/cf_03_after.sou
+++ b/examples/cf_03_after.sou
@@ -1,15 +1,19 @@
-  branch true la lb
-la:
-  branch true l1 l2
-lb:
-  branch true l2 l3
-l1:
+  branch true $la $lb
+$la:
+  branch true $l1 $l2_2
+$lb:
+  branch true $l2_1 $l3
+$l1:
   print 10
   goto fin
+$l2_2:
+  goto l2
+$l2_1:
+  goto l2
 l2:
   print 20
   goto fin
-l3:
+$l3:
   print 30
   goto fin
 fin:

--- a/examples/cf_03_before.sou
+++ b/examples/cf_03_before.sou
@@ -3,18 +3,22 @@
   var a = (10 + 0)
   var b = 20
   var c = 30
-  branch t la lb
-la:
-  branch t l1 l2
-lb:
-  branch t l2 l3
-l1:
+  branch t $la $lb
+$la:
+  branch t $l1 $l2_a
+$lb:
+  branch t $l2_b $l3
+$l1:
   print (a + 0)
   goto fin
+$l2_a:
+  goto l2
+$l2_b:
+  goto l2
 l2:
   print b
   goto fin
-l3:
+$l3:
   print c
   goto fin
 fin:

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -34,12 +34,13 @@ version old
  var z = 0
  read z
  osr deopt [] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
- branch (z == zero) l1 l2
-l1:
+ branch (z == zero) $l1 $l2
+$l1:
  x <- (x + one)
  goto end
-l2:
+$l2:
  x <- (x + two)
+ goto end
 end:
  # This assignment can be moved
  w1 <- (w1 + one)

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -11,7 +11,7 @@ version active
  var x = 30
  var z = 0
  read z
- osr [(z == zero)] (main,old,l1) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
+ osr deopt [(z == zero)] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)
@@ -33,6 +33,7 @@ version old
  var x = 30
  var z = 0
  read z
+ osr deopt [] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  branch (z == zero) l1 l2
 l1:
  x <- (x + one)

--- a/examples/cm_01_before.sou
+++ b/examples/cm_01_before.sou
@@ -8,12 +8,13 @@
   var x = 30
   var z = 0
   read z
-  branch (z == zero) l1 l2
-l1:
+  branch (z == zero) $l1 $l2
+$l1:
   x <- (x + one)
   goto end
-l2:
+$l2:
   x <- (x + two)
+  goto end
 end:
   # This assignment can be moved
   w1 <- (w1 + one)

--- a/examples/cm_02_after.sou
+++ b/examples/cm_02_after.sou
@@ -11,11 +11,12 @@
   print z
   # This assignment was moved
   z <- (x + y)
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/cm_02_before.sou
+++ b/examples/cm_02_before.sou
@@ -9,13 +9,14 @@
   var limit = 10
   read limit
   print z
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   # This assignment can be moved
   z <- (x + y)
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/cm_03_after.sou
+++ b/examples/cm_03_after.sou
@@ -7,12 +7,13 @@
   var x = 10
   var z = 0
   read z
-  branch (z == zero) l1 l2
-l1:
+  branch (z == zero) $l1 $l2
+$l1:
   x <- (x + one)
   goto end
-l2:
+$l2:
   x <- (x + two)
+  goto end
 end:
   # This statement was moved
   x <- (x + three)

--- a/examples/cm_03_before.sou
+++ b/examples/cm_03_before.sou
@@ -7,16 +7,17 @@
   var x = 10
   var z = 0
   read z
-  branch (z == zero) l1 l2
-l1:
+  branch (z == zero) $l1 $l2
+$l1:
   x <- (x + one)
   # This statement will be moved
   x <- (x + three)
   goto end
-l2:
+$l2:
   x <- (x + two)
   # This statement will be moved
   x <- (x + three)
+  goto end
 end:
   print x
   stop 0

--- a/examples/cm_04_after.sou
+++ b/examples/cm_04_after.sou
@@ -8,16 +8,20 @@
   var w = 0
   read w
   # The entire if-branch was moved
-  branch (w == zero) l1 l2
-l1:
+  branch (w == zero) $l1 $l2
+$l1:
   z <- (x + y)
-l2:
+  goto ft
+$l2:
+  goto ft
+ft:
   var limit = 10
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/cm_04_before.sou
+++ b/examples/cm_04_before.sou
@@ -8,16 +8,20 @@
   var w = 0
   read w
   var limit = 10
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
-  branch (w == zero) l1 l2
-l1:
+  branch (i == limit) $continue $loop_body
+$loop_body:
+  branch (w == zero) $l1 $l2
+$l1:
   # This statement cannot be moved (but the entire if-branch can)
   z <- (x + y)
-l2:
+  goto loop_body_2
+$l2:
+  goto loop_body_2
+loop_body_2:
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/complicated.sou
+++ b/examples/complicated.sou
@@ -2,11 +2,17 @@
  var y = 1
  read x
  var i = 0
-loop:
-  branch (x==1) c1 c2
- c1:
+ goto loop_
+$loop:
+ goto loop_
+loop_:
+  branch (x==1) $c1 $c2
+ $c1:
   y <- 2
- c2:
+  goto l2
+ $c2:
+  goto l2
+ l2:
   i <- (i+y)
- branch (i==10) end loop
-end:
+ branch (i==10) $end $loop
+$end:

--- a/examples/const_fold_test.sou
+++ b/examples/const_fold_test.sou
@@ -1,15 +1,16 @@
   var z
   read z
   var x
-  branch (z==1) l1 l2
-l1:
+  branch (z==1) $l1 $l2
+$l1:
   x <- 2
   print x
   # prints 2
   goto merge
-l2:
+$l2:
   x <- 3
   print x
   # prints 3
+  goto merge
 merge:
   print x

--- a/examples/double_loop.sou
+++ b/examples/double_loop.sou
@@ -2,23 +2,25 @@
  i <- 0
  var sum = 0
  var limit = 4
+ goto loop1
 loop1:
-  branch (i != limit) loop_body1 continue
-loop_body1:
+  branch (i != limit) $loop_body1 $continue
+$loop_body1:
    var i2 = 0
    var sum2 = 0
+   goto loop2
 loop2:
-    branch (i2 != limit) loop_body2 continue2
-loop_body2:
+    branch (i2 != limit) $loop_body2 $continue2
+$loop_body2:
      print i2
      sum2 <- (sum + i2)
      i2 <- (i2 + 1)
     goto loop2
-continue2:
+$continue2:
    sum <- (sum + sum2)
    drop i2
    drop sum2
    i <- (i + 1)
  goto loop1
-continue:
+$continue:
  print sum

--- a/examples/min_live_01_after.sou
+++ b/examples/min_live_01_after.sou
@@ -1,10 +1,13 @@
   var a = 12
   var b = false
-  branch b o1 o2
-o1:
+  branch b $o1 $o2
+$o1:
   a <- 1
   print a
-o2:
+  goto ft
+$o2:
+  goto ft
+ft:
   drop a
   print b
   drop b

--- a/examples/min_live_01_before.sou
+++ b/examples/min_live_01_before.sou
@@ -1,12 +1,15 @@
   var a = 12
   var b = false
   var c
-  branch b o1 o2
-o1:
+  branch b $o1 $o2
+$o1:
   a <- 22
   a <- 1
   print a
-o2:
+  goto o2m
+$o2:
+  goto o2m
+o2m:
   print b
   drop b
   goto x

--- a/examples/movedrop_01_after.sou
+++ b/examples/movedrop_01_after.sou
@@ -2,7 +2,7 @@
   var x
   # pulled from below the branch
   drop x
-  branch e l1 l2
-l1:
+  branch e $l1 $l2
+$l1:
   stop 0
-l2:
+$l2:

--- a/examples/movedrop_01_before.sou
+++ b/examples/movedrop_01_before.sou
@@ -1,9 +1,9 @@
   var e = true
   var x
-  branch e l1 l2
-l1:
+  branch e $l1 $l2
+$l1:
   # can be pulled above the branch
   drop x
   stop 0
-l2:
+$l2:
   drop x

--- a/examples/movedrop_03_after.sou
+++ b/examples/movedrop_03_after.sou
@@ -1,10 +1,10 @@
   var x = 1
-  branch (1==1) e1 e2
-e1:
+  branch (1==1) $e1 $e2
+$e1:
   # drop was hoisted
   drop x
   goto l
-e2:
+$e2:
   # drop was hoisted
   drop x
   goto l

--- a/examples/movedrop_03_before.sou
+++ b/examples/movedrop_03_before.sou
@@ -1,8 +1,8 @@
   var x = 1
-  branch (1==1) e1 e2
-e1:
+  branch (1==1) $e1 $e2
+$e1:
   goto l
-e2:
+$e2:
   goto l
 l:
   # drop can be hoisted

--- a/examples/movedrop_04_after.sou
+++ b/examples/movedrop_04_after.sou
@@ -1,15 +1,19 @@
-  branch (1 == 1) la lb
-la:
-  branch (1 == 1) l1 l2
-lb:
-  branch (2 == 2) l2 l3
-l1:
+  branch (1 == 1) $la $lb
+$la:
+  branch (1 == 1) $l1 $l2_a
+$lb:
+  branch (2 == 2) $l2_b $l3
+$l1:
   print 1
   goto die_ende
+$l2_a:
+  goto l2
+$l2_b:
+  goto l2
 l2:
   print 2
   goto die_ende
-l3:
+$l3:
   print 3
   goto die_ende
 die_ende:

--- a/examples/movedrop_04_before.sou
+++ b/examples/movedrop_04_before.sou
@@ -1,17 +1,21 @@
   # "annihilated" by hoisting the drop
   var x = 1
-  branch (1 == 1) la lb
-la:
-  branch (1 == 1) l1 l2
-lb:
-  branch (2 == 2) l2 l3
-l1:
+  branch (1 == 1) $la $lb
+$la:
+  branch (1 == 1) $l1 $l2_a
+$lb:
+  branch (2 == 2) $l2_b $l3
+$l1:
   print 1
   goto die_ende
+$l2_a:
+  goto l2
+$l2_b:
+  goto l2
 l2:
   print 2
   goto die_ende
-l3:
+$l3:
   print 3
   goto die_ende
 die_ende:

--- a/examples/mut_const_fold_test.sou
+++ b/examples/mut_const_fold_test.sou
@@ -3,15 +3,15 @@
   var x = 1
   var y
   var w = 1
-  branch (z==1) l1 l2
-l1:
+  branch (z==1) $l1 $l2
+$l1:
   print x
   # prints 1
   x <- 2
   y <- 2
   read w
   goto merge
-l2:
+$l2:
   x <- 3
   y <- 2
   print x

--- a/examples/no_cm_01.sou
+++ b/examples/no_cm_01.sou
@@ -8,16 +8,20 @@
   var w = 0
   read w
   var limit = 10
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
-  branch (w == i) l1 l2
-l1:
+  branch (i == limit) $continue $loop_body
+$loop_body:
+  branch (w == i) $l1 $l2
+$l1:
   # This statement cannot be moved (but the entire if-branch can)
   z <- (x + y)
-l2:
+  goto ft
+$l2:
+  goto ft
+ ft:
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/no_cm_02.sou
+++ b/examples/no_cm_02.sou
@@ -6,9 +6,10 @@
   var i = 0
   var acc = 0
   var limit = 10
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   # This statement cannot be moved
   z <- (x + y)
   acc <- (acc + z)
@@ -16,5 +17,5 @@ loop_body:
   print z
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/no_cm_03.sou
+++ b/examples/no_cm_03.sou
@@ -6,14 +6,15 @@
   var i = 0
   var acc = 0
   var limit = 10
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   print z
   # This statement cannot be moved
   z <- (x + y)
   acc <- (acc + z)
   i <- (i + one)
   goto loop
-continue:
+$continue:
 print acc

--- a/examples/regression_without_fallthrough.sou
+++ b/examples/regression_without_fallthrough.sou
@@ -1,4 +1,5 @@
 var x = 10
+goto label
 label:
 drop x
 print 1

--- a/examples/sum.sou
+++ b/examples/sum.sou
@@ -2,15 +2,16 @@
   var sum = 0
   var limit = 0
   read limit
+  goto loop
 loop:
-  branch (i == limit) continue loop_body
-loop_body:
+  branch (i == limit) $continue $loop_body
+$loop_body:
   print i
   sum <- (sum + i)
   i <- (i + 1)
   goto loop
 
-continue:
+$continue:
   drop i
   drop limit
 {sum}

--- a/lexer.mll
+++ b/lexer.mll
@@ -77,6 +77,7 @@ rule token = parse
   | "," { COMMA }
   | "..." { TRIPLE_DOT }
   | ":" { COLON }
+  | "$" { DOLLAR }
   | "=" { EQUAL }
   | "<-" { LEFTARROW }
   | "'" { SINGLE_QUOTE }

--- a/parser.messages
+++ b/parser.messages
@@ -1,37 +1,37 @@
-program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
+program: BRANCH NIL DOLLAR IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 130.
 ##
-## instruction -> BRANCH expression label . label [ NEWLINE ]
+## instruction -> BRANCH expression DOLLAR label . DOLLAR label [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## BRANCH expression label 
+## BRANCH expression DOLLAR label 
 ##
 
-Parsing an instruction, we parsed "branch <expr> <label>" so far;
-a label, for example "foo", is now expected to construct a branch
+Parsing an instruction, we parsed "branch <expr> $<label>" so far;
+a label, for example "$foo", is now expected to construct a branch
 instruction
-"branch <expr> <label> <label>".
+"branch <expr> $<label> $<label>".
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 128.
 ##
-## instruction -> BRANCH expression . label label [ NEWLINE ]
+## instruction -> BRANCH expression . DOLLAR label DOLLAR label [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## BRANCH expression 
 ##
 
 Parsing an instruction, we parsed "branch <expr>" so far; a label, for
-example "foo", is now expected to construct a branch instruction
-"branch <expr> <label> <label>".
+example "$foo", is now expected to construct a branch instruction
+"branch <expr> $<label> $<label>".
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 127.
 ##
-## instruction -> BRANCH . expression label label [ NEWLINE ]
+## instruction -> BRANCH . expression DOLLAR label DOLLAR label [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## BRANCH 
@@ -39,7 +39,7 @@ program: BRANCH TRIPLE_DOT
 
 Parsing an instruction, we parsed "branch" so far; an expression, for
 example "(x == 2)", is now expected to construct a branch instruction
-"branch <expr> <label> <label>".
+"branch <expr> $<label> $<label>".
 
 program: VAR IDENTIFIER EQUAL TRIPLE_DOT 
 ##
@@ -101,7 +101,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 145.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -265,7 +265,7 @@ program: LBRACE STOP
 ##
 ## Ends in an error in state: 5.
 ##
-## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
+## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP DOLLAR COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE 
@@ -282,7 +282,7 @@ program: LBRACE TRIPLE_DOT RBRACE BOOL
 ##
 ## Ends in an error in state: 12.
 ##
-## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
+## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP DOLLAR COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope RBRACE 
@@ -295,7 +295,7 @@ program: LBRACE TRIPLE_DOT TRIPLE_DOT
 ##
 ## Ends in an error in state: 11.
 ##
-## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
+## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP DOLLAR COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope 
@@ -308,7 +308,7 @@ program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT
 ##
 ## Ends in an error in state: 57.
 ##
-## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE LPAREN DOLLAR COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression infixop simple_expression 
@@ -321,7 +321,7 @@ program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT
 ##
 ## Ends in an error in state: 56.
 ##
-## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN DOLLAR COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression infixop 
@@ -335,7 +335,7 @@ program: PRINT LPAREN IDENTIFIER TRIPLE_DOT
 ##
 ## Ends in an error in state: 42.
 ##
-## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN DOLLAR COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN simple_expression 
@@ -349,8 +349,8 @@ program: PRINT LPAREN TRIPLE_DOT
 ##
 ## Ends in an error in state: 36.
 ##
-## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
-## expression -> LPAREN . prefixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN DOLLAR COMMA ]
+## expression -> LPAREN . prefixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN DOLLAR COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN 
@@ -393,9 +393,9 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 156.
 ##
-## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
+## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP DOLLAR COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction NEWLINE 
@@ -406,9 +406,9 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 155.
 ##
-## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP DOLLAR COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction 

--- a/parser.messages
+++ b/parser.messages
@@ -1,6 +1,6 @@
 program: BRANCH NIL IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 126.
 ##
 ## instruction -> BRANCH expression label . label [ NEWLINE ]
 ##
@@ -15,7 +15,7 @@ instruction
 
 program: BRANCH NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 125.
 ##
 ## instruction -> BRANCH expression . label label [ NEWLINE ]
 ##
@@ -29,7 +29,7 @@ example "foo", is now expected to construct a branch instruction
 
 program: BRANCH TRIPLE_DOT 
 ##
-## Ends in an error in state: 119.
+## Ends in an error in state: 124.
 ##
 ## instruction -> BRANCH . expression label label [ NEWLINE ]
 ##
@@ -43,9 +43,9 @@ example "(x == 2)", is now expected to construct a branch instruction
 
 program: VAR IDENTIFIER EQUAL TRIPLE_DOT 
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 32.
 ##
-## instruction -> VAR variable EQUAL . expression [ NEWLINE ]
+## var_def -> VAR variable EQUAL . expression [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR variable EQUAL 
@@ -57,9 +57,10 @@ example "(x + 1)", is now expected to construct a variable declaration
 
 program: VAR IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 31.
 ##
-## instruction -> VAR variable . EQUAL expression [ NEWLINE ]
+## var_def -> VAR variable . EQUAL expression [ RBRACKET NEWLINE COMMA ]
+## var_def -> VAR variable . [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR variable 
@@ -71,9 +72,10 @@ Parsing an instruction, we parsed "var <var>" so far; the equal sign
 
 program: VAR TRIPLE_DOT 
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 30.
 ##
-## instruction -> VAR . variable EQUAL expression [ NEWLINE ]
+## var_def -> VAR . variable EQUAL expression [ RBRACKET NEWLINE COMMA ]
+## var_def -> VAR . variable [ RBRACKET NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## VAR 
@@ -85,7 +87,7 @@ example "x", is now expected to construct a variable declaration
 
 program: GOTO TRIPLE_DOT 
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 107.
 ##
 ## instruction -> GOTO . label [ NEWLINE ]
 ##
@@ -99,7 +101,7 @@ Parsing an instruction, we parsed "goto" so far; a label, for example
 
 program: IDENTIFIER LEFTARROW TRIPLE_DOT 
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 140.
 ##
 ## instruction -> variable LEFTARROW . expression [ NEWLINE ]
 ##
@@ -113,10 +115,10 @@ for example "(x + 1)", is now expected to construct an assignment
 
 program: IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 106.
 ##
 ## label -> IDENTIFIER . [ COLON ]
-## variable -> IDENTIFIER . [ LEFTARROW ]
+## variable -> IDENTIFIER . [ LEFTARROW LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENTIFIER 
@@ -126,93 +128,93 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 - if this is a label declaration, we expect a semicolon: "<label>:"
 - if this is an assignment, we expect a left arrow: "<var> <- <expression>"
 
-program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 95.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET 
 ##
 
 There was an error parsing the specification of the new environment of an
 osr instruction. The specification is a comma-separated list of terms of the form
 "const x = e" (where "e" is an expression), "mut x = e", "mut x = &y"
 or just "mut x". For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 94.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
 ##
 
 After "osr [...] (...) " we expect the specification of the new environment.
 It is a square bracket enclosed, comma-separated list
 of terms of the form "const x = e" (where "e" is an expression),
 "mut x = e", "mut x = &y" or just "mut x". For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 
-program: OSR LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
 ##
-## Ends in an error in state: 61.
+## Ends in an error in state: 88.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
 ##
 
 Parsing an osr instruction, there is an error with the syntax of the target
 location "(function, version, label)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET NIL RBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET NIL RBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 87.
 ##
-## instruction -> OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
+## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
 ##
 
-Parsing an osr instruction, we parsed "osr [<expr> ...]", and are
+Parsing an osr instruction, we parsed "osr l [<expr> ...]", and are
 now expecting a target location "(function, version, label)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
-program: OSR LBRACKET TRIPLE_DOT 
+program: OSR IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 84.
 ##
-## instruction -> OSR LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR label LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
-## OSR LBRACKET 
+## OSR label LBRACKET 
 ##
 
 Parsing an osr instruction, there was an error parsing the list of conditions.
 Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 
 program: OSR TRIPLE_DOT 
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 81.
 ##
-## instruction -> OSR . LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
+## instruction -> OSR . label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN LBRACKET loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR 
@@ -220,9 +222,9 @@ program: OSR TRIPLE_DOT
 
 Parsing an osr instruction, we parsed "osr", and are now expecting a bracket
 enclosed list of conditions. Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr [<conditions>] (<target>) [<osr-map>]",
+The complete instruction syntax is "osr <label> [<conditions>] (<target>) [<osr-map>]",
 For example,
-"osr [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
+"osr l [(a==1)] (Main,optimized,l2) [const x = e, mut y = &y, mut z]".
 
 program: LBRACE IDENTIFIER COMMA STOP 
 ##
@@ -263,7 +265,7 @@ program: LBRACE STOP
 ##
 ## Ends in an error in state: 5.
 ##
-## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE . scope RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE 
@@ -280,7 +282,7 @@ program: LBRACE TRIPLE_DOT RBRACE BOOL
 ##
 ## Ends in an error in state: 12.
 ##
-## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE scope RBRACE . optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope RBRACE 
@@ -293,7 +295,7 @@ program: LBRACE TRIPLE_DOT TRIPLE_DOT
 ##
 ## Ends in an error in state: 11.
 ##
-## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ STOP RETURN READ PRINT OSR MUT IDENTIFIER GOTO DROP VAR COMMENT CLEAR CALL BRANCH ]
+## scope_annotation -> LBRACE scope . RBRACE optional_newlines [ VAR STOP RETURN READ PRINT OSR IDENTIFIER GOTO DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE scope 
@@ -304,7 +306,7 @@ In a scope annotation, "..." should be the last item. "{ x, ... }" or
 
 program: PRINT LPAREN IDENTIFIER PLUS IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 57.
 ##
 ## expression -> LPAREN simple_expression infixop simple_expression . RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -317,7 +319,7 @@ a closing parenthesis ")" is now expected.
 
 program: PRINT LPAREN IDENTIFIER PLUS TRIPLE_DOT 
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 56.
 ##
 ## expression -> LPAREN simple_expression infixop . simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -331,7 +333,7 @@ Parsing an expression, we parsed "( <arg> <op>" so far; an argument
 
 program: PRINT LPAREN IDENTIFIER TRIPLE_DOT 
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 42.
 ##
 ## expression -> LPAREN simple_expression . infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
@@ -348,6 +350,7 @@ program: PRINT LPAREN TRIPLE_DOT
 ## Ends in an error in state: 36.
 ##
 ## expression -> LPAREN . simple_expression infixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
+## expression -> LPAREN . prefixop simple_expression RPAREN [ RPAREN RBRACKET NEWLINE LPAREN IDENTIFIER COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN 
@@ -359,7 +362,7 @@ literal value) is now expected to construct an expression
 
 program: PRINT TRIPLE_DOT 
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 79.
 ##
 ## instruction -> PRINT . expression [ NEWLINE ]
 ##
@@ -374,7 +377,7 @@ to construct a print instruction
 
 program: READ TRIPLE_DOT 
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 77.
 ##
 ## instruction -> READ . variable [ NEWLINE ]
 ##
@@ -390,9 +393,9 @@ Note that the variable needs to have been declared as mutable first.
 
 program: STOP NIL NEWLINE TRIPLE_DOT 
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 151.
 ##
-## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP VAR COMMENT CLEAR CALL BRANCH ]
+## instruction_line -> scope_annotation instruction NEWLINE . optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction NEWLINE 
@@ -403,9 +406,9 @@ instruction on the next line, or the end of the file.
 
 program: STOP NIL TRIPLE_DOT 
 ##
-## Ends in an error in state: 128.
+## Ends in an error in state: 150.
 ##
-## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION STOP RETURN READ PRINT OSR MUT LBRACE IDENTIFIER GOTO FUNCTION EOF DROP VAR COMMENT CLEAR CALL BRANCH ]
+## instruction_line -> scope_annotation instruction . NEWLINE optional_newlines [ VERSION VAR STOP RETURN READ PRINT OSR LBRACE IDENTIFIER GOTO FUNCTION EOF DROP COMMENT CALL BRANCH ASSERT ARRAY ]
 ##
 ## The known suffix of the stack is as follows:
 ## scope_annotation instruction 

--- a/parser.mly
+++ b/parser.mly
@@ -5,7 +5,7 @@
 %token SINGLE_QUOTE
 %token DOUBLE_EQUAL NOT_EQUAL LT LTE GT GTE PLUS MINUS TIMES DIVIDE MOD DOUBLE_AMP DOUBLE_PIPE BANG
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
-%token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA
+%token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA DOLLAR
 %token VAR BRANCH GOTO PRINT ASSERT OSR STOP READ DROP RETURN CALL VERSION FUNCTION
 %token ARRAY LENGTH
 %token<string> COMMENT
@@ -125,10 +125,12 @@ instruction:
   { Assign (x, e) }
 | x=variable LBRACKET i=expression RBRACKET LEFTARROW e=expression
   { Array_assign (x, i, e) }
-| BRANCH e=expression l1=label l2=label
+| BRANCH e=expression DOLLAR l1=label DOLLAR l2=label
   { Branch (e, l1, l2) }
 | l=label COLON
-  { Label l }
+  { Label (MergeLabel l) }
+| DOLLAR l=label COLON
+  { Label (BranchLabel l) }
 | GOTO l=label
   { Goto l }
 | READ x=variable

--- a/parser.mly
+++ b/parser.mly
@@ -140,10 +140,11 @@ instruction:
 | ASSERT e=expression
   { Assert e }
 | OSR
+  label=label
   LBRACKET cond=separated_list(COMMA, expression) RBRACKET
   LPAREN func=label COMMA version=label COMMA pos=label RPAREN
   LBRACKET map=separated_list(COMMA, osr_def) RBRACKET
-  { Osr {cond; target= {func; version; pos}; map} }
+  { Osr {label; cond; target= {func; version; pos}; map} }
 | STOP e=expression
   { Stop e }
 | s=COMMENT

--- a/transform.ml
+++ b/transform.ml
@@ -134,7 +134,6 @@ let optimize (opts : string list) (prog : program) : program option =
         (as_opt_program (as_opt_function Transform_assumption.hoist_assumption));
         optimizer;
         (as_opt_program (as_opt_function Transform_assumption.remove_empty_osr));
-        (as_opt_program Transform_assumption.remove_checkpoint_labels);
         optimizer_classic;
       ]
     else optimizer

--- a/transform_assumption.ml
+++ b/transform_assumption.ml
@@ -137,6 +137,7 @@ let insert_assumption (func : afunction) osr_cond pc : version option =
  * out of a loop:
  *
  *    osr [] ...
+ *    goto loop
  *   loop:
  *    print (x+1)
  *    osr [x==1] ...
@@ -145,6 +146,7 @@ let insert_assumption (func : afunction) osr_cond pc : version option =
  *   cont:
  *   ===================>
  *    osr [x==1] ...
+ *    goto loop
  *   loop:
  *    print (x+1)
  *    osr [] ...
@@ -159,7 +161,7 @@ let insert_assumption (func : afunction) osr_cond pc : version option =
  * In the above example:
  * 0. We can move the assumption to `loop:` because `print (x+1)` is
  *    independent of x==1.
- * 1. There is an unique dominator (ie. the fallthrough one)
+ * 1. There is an unique dominator (ie. the loop entry)
  * 2. On the other predecessor (ie. the branch instruction) the assumption
  *    is available because `print x` is independent of x==1.
  *)

--- a/transform_cleanup.ml
+++ b/transform_cleanup.ml
@@ -8,7 +8,7 @@ let remove_jmp : transform_instructions = fun ({instrs; _} as inp) ->
   let transform pc =
     if (pc+1) = Array.length instrs then Unchanged else
     match[@warning "-4"] instrs.(pc), instrs.(pc+1) with
-    | Goto l1, Label l2 when l1 = l2 && pred.(pc+1) = [pc] ->
+    | Goto l1, Label (MergeLabel l2) when l1 = l2 && pred.(pc+1) = [pc] ->
       Remove 2
     | Label l, _ when
         pred.(pc) = [pc-1] && succ.(pc-1) = [pc] ->

--- a/transform_cleanup.ml
+++ b/transform_cleanup.ml
@@ -9,11 +9,9 @@ let remove_jmp : transform_instructions = fun ({instrs; _} as inp) ->
     if (pc+1) = Array.length instrs then Unchanged else
     match[@warning "-4"] instrs.(pc), instrs.(pc+1) with
     | Goto l1, Label l2 when l1 = l2 && pred.(pc+1) = [pc] ->
-      Remove (if is_checkpoint_label l1 then 1 else 2)
+      Remove 2
     | Label l, _ when
-        pred.(pc) = [pc-1] &&
-        succ.(pc-1) = [pc] &&
-        not (is_checkpoint_label l) ->
+        pred.(pc) = [pc-1] && succ.(pc-1) = [pc] ->
         (* A label is unused if the previous instruction is the only predecessor
          * unless the previous instruction jumps to it. The later can happen
          * if its a goto (then we already remove it -- see above) or if its a branch (which


### PR DESCRIPTION
This change enforces a more rigorous graph discipline. There is a distinction
between merge labels and branch labels. Merge labels can have an arbitrary
number of incomming 'gotos'. Branch labels can have exactly one incomming
source from a branch instruction.

To make checking the graph a local property branch labels must begin with '$'.

The graph discipline is strictly enforced in the check module.

In theory merge labels would not have a problem with fallthrough controlflow.
But to make the structure uniform fallthrough is forbidden too.

The change simplifies reasoning about instruction movements as can be seen
in the hoist_drop pass.

depends on #142  and obsoletes #138 