### PR TITLE
inlining: fix var and label renaming

### DIFF
--- a/edit.ml
+++ b/edit.ml
@@ -9,7 +9,16 @@ let fresh (existing : StringSet.t) (name : string) : string =
   let rec find i =
     let cand_var = cand i in
     if is_fresh cand_var then cand_var else find (i+1) in
-  find 1
+  if is_fresh name
+  then name
+  else find 1
+
+let fresh_many existing names =
+  let replace (used, acc) old =
+    let fresh_var = fresh used old in
+    (VarSet.add fresh_var used, (old, fresh_var) :: acc)
+  in
+  snd (List.fold_left replace (existing, []) names)
 
 let fresh_var instrs var =
   let existing = Array.fold_left


### PR DESCRIPTION
To rename variables and labels we cannot call `fresh` on all
existing variables in parallel. For example consider the function:

```
caller:
  var x = 1

callee:
  var x   = 1
  var x_1 = 2
```

In general any try to do the renaming in parallel makes unreasonable
assumptions about how `fresh` is implemented. For example it would be
perfectly reasonable for `fresh` to always return `foo` if it's fresh.

Thus the only way of using fresh which does not make assumptions on
how it works is to always feed back the generated names to avoid generating
the same name again.