### PR TITLE
fix constantfolding type confusion

### DIFF
--- a/check.ml
+++ b/check.ml
@@ -86,9 +86,9 @@ let well_formed prog =
         | Unop (_op, e) ->
           check_simple_expr e
         | Binop (_op, e1, e2) ->
-            check_simple_expr e1;
-            check_simple_expr e2
-        | Array_index(_, i) ->
+          check_simple_expr e1;
+          check_simple_expr e2
+        | Array_index (_, i) ->
           check_simple_expr i
         | Array_length (e) ->
           check_simple_expr e in

--- a/check.ml
+++ b/check.ml
@@ -83,8 +83,15 @@ let well_formed prog =
       in
       let check_expr = function
         | Simple e -> check_simple_expr e
-        | Op (_op, xs) ->
-          List.iter check_simple_expr xs in
+        | Unop (_op, e) ->
+          check_simple_expr e
+        | Binop (_op, e1, e2) ->
+            check_simple_expr e1;
+            check_simple_expr e2
+        | Array_index(_, i) ->
+          check_simple_expr i
+        | Array_length (e) ->
+          check_simple_expr e in
       let check_arg = check_expr in
       let check_osr = function
         | Osr_var (_, e) -> check_expr e

--- a/disasm.ml
+++ b/disasm.ml
@@ -19,28 +19,24 @@ let disassemble_instrs buf ?(format_pc = no_line_number) (prog : instructions) =
     in
     let dump_expr buf exp =
       match exp with
-      | Simple e          -> simple buf e
-      | Op (Neg,  [a])    -> pr buf "(-%a)"      simple a
-      | Op (Plus, [a; b]) -> pr buf "(%a + %a)"  simple a simple b
-      | Op (Sub,  [a; b]) -> pr buf "(%a - %a)"  simple a simple b
-      | Op (Mult, [a; b]) -> pr buf "(%a * %a)"  simple a simple b
-      | Op (Div,  [a; b]) -> pr buf "(%a / %a)"  simple a simple b
-      | Op (Mod,  [a; b]) -> pr buf "(%a %% %a)" simple a simple b
-      | Op (Eq,   [a; b]) -> pr buf "(%a == %a)" simple a simple b
-      | Op (Neq,  [a; b]) -> pr buf "(%a != %a)" simple a simple b
-      | Op (Lt,   [a; b]) -> pr buf "(%a < %a)"  simple a simple b
-      | Op (Lte,  [a; b]) -> pr buf "(%a <= %a)" simple a simple b
-      | Op (Gt,   [a; b]) -> pr buf "(%a > %a)"  simple a simple b
-      | Op (Gte,  [a; b]) -> pr buf "(%a >= %a)" simple a simple b
-      | Op (Not,  [a])    -> pr buf "(!%a)"      simple a
-      | Op (And,  [a; b]) -> pr buf "(%a && %a)" simple a simple b
-      | Op (Or,   [a; b]) -> pr buf "(%a || %a)" simple a simple b
-      | Op ((Neg | Plus | Sub | Mult | Div | Mod), _)
-      | Op ((Eq | Neq | Lt | Lte | Gt | Gte), _)
-      | Op ((Not | And | Or), _) -> assert(false)
-      | Op (Array_index, [array; index]) -> pr buf "%a[%a]" simple array simple index
-      | Op (Array_length, [array]) -> pr buf "length(%a)" simple array
-      | Op ((Array_index | Array_length), _) -> assert(false)
+      | Simple e           -> simple buf e
+      | Unop (Neg, a)      -> pr buf "(-%a)"      simple a
+      | Unop (Not, a)      -> pr buf "(!%a)"      simple a
+      | Binop (Plus, a, b) -> pr buf "(%a + %a)"  simple a simple b
+      | Binop (Sub,  a, b) -> pr buf "(%a - %a)"  simple a simple b
+      | Binop (Mult, a, b) -> pr buf "(%a * %a)"  simple a simple b
+      | Binop (Div,  a, b) -> pr buf "(%a / %a)"  simple a simple b
+      | Binop (Mod,  a, b) -> pr buf "(%a %% %a)" simple a simple b
+      | Binop (Eq,   a, b) -> pr buf "(%a == %a)" simple a simple b
+      | Binop (Neq,  a, b) -> pr buf "(%a != %a)" simple a simple b
+      | Binop (Lt,   a, b) -> pr buf "(%a < %a)"  simple a simple b
+      | Binop (Lte,  a, b) -> pr buf "(%a <= %a)" simple a simple b
+      | Binop (Gt,   a, b) -> pr buf "(%a > %a)"  simple a simple b
+      | Binop (Gte,  a, b) -> pr buf "(%a >= %a)" simple a simple b
+      | Binop (And,  a, b) -> pr buf "(%a && %a)" simple a simple b
+      | Binop (Or,   a, b) -> pr buf "(%a || %a)" simple a simple b
+      | Array_index (a, i) -> pr buf "%s[%a]"     a simple i
+      | Array_length e     -> pr buf "length(%a)" simple e
     in
     let dump_arg buf arg = dump_expr buf arg in
     format_pc buf pc;

--- a/parser.mly
+++ b/parser.mly
@@ -161,13 +161,13 @@ argument: e=expression { e }
 expression:
   | e = simple_expression { Simple e }
   | LPAREN e1=simple_expression op=infixop e2=simple_expression RPAREN
-    { Op (op, [e1;e2]) }
+    { Binop (op, e1, e2) }
   | LPAREN op=prefixop e=simple_expression RPAREN
-    { Op (op, [e]) }
+    { Unop (op, e) }
   | x=variable LBRACKET index=simple_expression RBRACKET
-    { Op (Array_index, [Var x; index]) }
-  | LENGTH LPAREN x=simple_expression RPAREN
-    { Op (Array_length, [x]) }
+    { Array_index (x, index) }
+  | LENGTH LPAREN e=simple_expression RPAREN
+    { Array_length e }
 
 label: id=IDENTIFIER { (id : Label.t) }
 variable: id=IDENTIFIER { (id : Variable.t) }

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -67,7 +67,8 @@ let const_fold : transform_instructions = fun {formals; instrs} ->
     let update pc cur =
       let approx env exp = match (fold env)#expression exp with
         | Simple (Constant l) -> Value l
-        | Simple (Var _) | Op _ -> Unknown
+        | Simple (Var _)
+        | Unop _ | Binop _ | Array_index _ | Array_length _ -> Unknown
       in
       match[@warning "-4"] instrs.(pc) with
       | Decl_var (x, e)

--- a/transform_hoist_assign.ml
+++ b/transform_hoist_assign.ml
@@ -67,9 +67,9 @@ let hoist_assignment : transform_instructions = fun ({formals; instrs} as inp) -
       let pc' = pc + 1 in
       match[@warning "-4"] instrs.(pc) with
       | Assign (x, exp) ->
-        let is_simple = function
+        let is_simple = function[@warning "-4"]
           | Simple _ -> true
-          | Op _ -> false in
+          | _ -> false in
         if (not (dominates_all_uses pc)) || (aliased x pc) || not (is_simple exp)
         then find_possible_move pc'
         else begin


### PR DESCRIPTION
constant fold would happily convert `a[b]` into `nil[b]`. The main
reason is that our operations where not "typed" and therefore we
had no way of specifying which position should be a variable or an
arbitrary expression.

This commit changes the structure of expressions to syntactically
enforce the correct argument types.