### PR TITLE
use the OCaml native compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ OCAMLBUILD+= -plugin-tag 'package(bisect_ppx.ocamlbuild)'
 all: tests test_examples sourir
 
 tests:
-	$(OCAMLBUILD) tests.byte
-	_build/tests.byte
+	$(OCAMLBUILD) tests.native
+	_build/tests.native
 
 sourir:
-	$(OCAMLBUILD) sourir.byte
-	cp _build/sourir.byte sourir
+	$(OCAMLBUILD) sourir.native
+	cp _build/sourir.native sourir
 
 lib:
 	$(OCAMLBUILD) sourir.cma


### PR DESCRIPTION
The bytecode compiler compiles faster (and is more incremental) than
the native compiler, so I guess I used it at the start for convenience
of development. Given that build times remain small and that we are
starting to hit performance issues, let's move to the real deal now --
as we probably should have a while ago.