### PR TITLE
Rename

### DIFF
--- a/disasm.ml
+++ b/disasm.ml
@@ -61,9 +61,9 @@ let disassemble_instrs buf ?(ott_compatible = false) ?(format_pc = no_line_numbe
     | Print exp                       -> pr buf " print %a" dump_expr exp
     | Assert exp                      -> pr buf " assert %a" dump_expr exp
     | Read var                        -> pr buf " read %s" var
-    | Osr {label; cond; target={func; version; pos}; varmap; frame_maps} ->
+    | Assumption {label; guards; target={func; version; pos}; varmap; extra_frames} ->
       let dump_var buf = function
-        | Osr_var (x, e)     -> pr buf "var %s = %a" x dump_expr e
+        | x, e -> pr buf "var %s = %a" x dump_expr e
       in
       let dump_frame buf {cont_pos={func; version; pos}; cont_res; varmap} =
         pr buf "(%s, %s, %s) [var %s = $%s%a]"
@@ -72,13 +72,13 @@ let disassemble_instrs buf ?(ott_compatible = false) ?(format_pc = no_line_numbe
             (if varmap = [] then "" else ", ")
             (dump_comma_separated dump_var) varmap
       in
-      pr buf " osr %s [%a] (%s, %s, %s) [%a]%s%a"
+      pr buf " assumption %s [%a] (%s, %s, %s) [%a]%s%a"
         label
-        (dump_comma_separated dump_expr) cond
+        (dump_comma_separated dump_expr) guards
         func version pos
         (dump_comma_separated dump_var) varmap
-        (if frame_maps = [] then "" else ", ")
-        (dump_comma_separated dump_frame) frame_maps
+        (if extra_frames = [] then "" else ", ")
+        (dump_comma_separated dump_frame) extra_frames
     | Comment str                     -> pr buf " #%s" str
     end;
     pr buf "\n"

--- a/eval.ml
+++ b/eval.ml
@@ -251,7 +251,7 @@ let instruction conf =
 let reduce conf =
   let eval conf e = eval conf.heap conf.env e in
   let resolve instrs label = Instr.resolver instrs label in
-  let resolve_osr instrs label = Instr.resolver_osr instrs label in
+  let resolve_bailout instrs label = Instr.resolver_bailout instrs label in
   let pc' = conf.pc + 1 in
   assert (conf.status = Running);
 
@@ -265,7 +265,7 @@ let reduce conf =
   in
 
   let build_osr_frame varmap old_env old_heap =
-    let add (env, heap) (Osr_var (x, e)) =
+    let add (env, heap) (x, e) =
       (Env.add x (Val (eval conf e)) env, heap)
     in
     List.fold_left add (Env.empty, old_heap) varmap
@@ -280,7 +280,7 @@ let reduce conf =
     let pos = {
       func = cont_pos.func;
       version = cont_pos.version;
-      pos = resolve_osr version.instrs cont_pos.pos} in
+      pos = resolve_bailout version.instrs cont_pos.pos} in
     heap, (cont_res, osr_env, pos) :: frames
   in
 
@@ -387,21 +387,21 @@ let reduce conf =
           pc = pc';
         }
     end
-  | Osr {cond; target={func;version; pos=label}; varmap; frame_maps} ->
-    let triggered = List.exists (fun cond -> get_bool (eval conf cond)) cond in
-    if not triggered then
+  | Assumption {guards; target={func;version; pos=label}; varmap; extra_frames} ->
+    let failed = List.exists (fun guard -> not (get_bool (eval conf guard))) guards in
+    if not failed then
       { conf with
         pc = pc';
       }
     else begin
       let osr_env, heap = build_osr_frame varmap conf.env conf.heap in
       let heap, extra_frames =
-        List.fold_left build_extra_osr_frame (heap, []) (List.rev frame_maps) in
+        List.fold_left build_extra_osr_frame (heap, []) (List.rev extra_frames) in
       let func = Instr.lookup_fun conf.program func in
       let version = Instr.get_version func version in
       let instrs = version.instrs in
       { conf with
-        pc = resolve_osr instrs label;
+        pc = resolve_bailout instrs label;
         env = osr_env;
         heap;
         instrs = instrs;

--- a/examples/cm_01_after.sou
+++ b/examples/cm_01_after.sou
@@ -11,7 +11,7 @@ version active
  var x = 30
  var z = 0
  read z
- osr deopt [(z == zero)] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
+ assumption deopt [(z != zero)] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  x <- (x + two)
  # This assignment can be moved
  w1 <- (w1 + one)
@@ -33,7 +33,7 @@ version old
  var x = 30
  var z = 0
  read z
- osr deopt [] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
+ assumption deopt [] (main,old,deopt) [var one = one, var two = two, var w1 = w1, var w2 = w2, var x = x, var z = z, var zero = zero]
  branch (z == zero) $l1 $l2
 $l1:
  x <- (x + one)

--- a/examples/inline_osr2_opt.sou
+++ b/examples/inline_osr2_opt.sou
@@ -10,7 +10,7 @@ version inlined_version
  var local_m2 = (x_m2 + 8)
  var res = nil
  var choice = x_m2
- osr cp_0 [(choice == 0)] (foo, anon, cp_0) [var choice = choice], (m2, anon, cp_2) [var res_m2 = $, var local_m2 = local_m2, var x_m2 = x_m2], (m1, anon, cp_2) [var res_m1 = $, var local_m1 = local_m1, var x_m1 = x_m1], (main, anon, cp_3) [var foo_res = $, var local_main = local_main, var user_input = user_input]
+ assumption cp_0 [(choice != 0)] (foo, anon, cp_0) [var choice = choice], (m2, anon, cp_2) [var res_m2 = $, var local_m2 = local_m2, var x_m2 = x_m2], (m1, anon, cp_2) [var res_m1 = $, var local_m1 = local_m1, var x_m1 = x_m1], (main, anon, cp_3) [var foo_res = $, var local_main = local_main, var user_input = user_input]
  res <- 0
  drop choice
  var res_m2 = res
@@ -35,29 +35,29 @@ version anon
  var user_input = 1
  var local_main = (3 + user_input)
  call foo_res = 'm1 (user_input)
- osr cp_3 [] (main, anon, cp_3) [var foo_res = foo_res, var local_main = local_main, var user_input = user_input]
+ assumption cp_3 [] (main, anon, cp_3) [var foo_res = foo_res, var local_main = local_main, var user_input = user_input]
  print foo_res
  print local_main
 function m1 (var x_m1)
 version anon
  var local_m1 = (x_m1 + 7)
  call res_m1 = 'm2 (x_m1)
- osr cp_2 [] (m1, anon, cp_2) [var local_m1 = local_m1, var res_m1 = res_m1, var x_m1 = x_m1]
+ assumption cp_2 [] (m1, anon, cp_2) [var local_m1 = local_m1, var res_m1 = res_m1, var x_m1 = x_m1]
  print local_m1
  return res_m1
 function m2 (var x_m2)
 version anon
  var local_m2 = (x_m2 + 8)
  call res_m2 = 'foo (x_m2)
- osr cp_2 [] (m2, anon, cp_2) [var local_m2 = local_m2, var res_m2 = res_m2, var x_m2 = x_m2]
+ assumption cp_2 [] (m2, anon, cp_2) [var local_m2 = local_m2, var res_m2 = res_m2, var x_m2 = x_m2]
  print local_m2
  return res_m2
 function foo (var choice)
 version anon_1
- osr cp_0 [(choice == 0)] (foo, anon, cp_0) [var choice = choice]
+ assumption cp_0 [(choice != 0)] (foo, anon, cp_0) [var choice = choice]
  return 0
 version anon
- osr cp_0 [] (foo, anon, cp_0) [var choice = choice]
+ assumption cp_0 [] (foo, anon, cp_0) [var choice = choice]
  branch (choice == 0) $a $b
 $a:
  return 1

--- a/examples/inline_osr_opt.sou
+++ b/examples/inline_osr_opt.sou
@@ -5,7 +5,7 @@ version inlined_version
  var local_var = (3 + user_input)
  var res = nil
  var choice = user_input
- osr cp_0 [(choice == 0)] (foo, anon, cp_0) [var choice = choice], (main, anon, cp_4) [var foo_res = $, var local_var = local_var, var user_input = user_input]
+ assumption cp_0 [(choice != 0)] (foo, anon, cp_0) [var choice = choice], (main, anon, cp_4) [var foo_res = $, var local_var = local_var, var user_input = user_input]
  drop choice
  drop res
  print 0
@@ -15,15 +15,15 @@ version anon
  read user_input
  var local_var = (3 + user_input)
  call foo_res = 'foo (user_input)
- osr cp_4 [] (main, anon, cp_4) [var foo_res = foo_res, var local_var = local_var, var user_input = user_input]
+ assumption cp_4 [] (main, anon, cp_4) [var foo_res = foo_res, var local_var = local_var, var user_input = user_input]
  print foo_res
  print local_var
 function foo (var choice)
 version anon_1
- osr cp_0 [(choice == 0)] (foo, anon, cp_0) [var choice = choice]
+ assumption cp_0 [(choice != 0)] (foo, anon, cp_0) [var choice = choice]
  return 0
 version anon
- osr cp_0 [] (foo, anon, cp_0) [var choice = choice]
+ assumption cp_0 [] (foo, anon, cp_0) [var choice = choice]
  branch (choice == 0) $a $b
 $a:
  return 1

--- a/instr.ml
+++ b/instr.ml
@@ -400,6 +400,7 @@ class map = object (m)
   method variable_use x = x
   method variable_assign x = x
   method binder x = x
+  method varmap_binder x = x
 
   method value v = v
 
@@ -489,5 +490,5 @@ class map = object (m)
   }
   method varmap = List.map m#varmap_entry
   method varmap_entry = function
-    | x, e -> m#binder x, m#expression e
+    | x, e -> m#varmap_binder x, m#expression e
 end

--- a/instr.ml
+++ b/instr.ml
@@ -108,6 +108,29 @@ and binop =
   | And
   | Or
 
+let negate = function
+  | Simple (Var x)                  -> Some (Unop (Not, (Var x)))
+  | Simple (Constant (Bool false))  -> Some (Simple (Constant (Bool true)))
+  | Simple (Constant (Bool true))   -> Some (Simple (Constant (Bool false)))
+  | Unop (Not, se)                  -> Some (Simple se)
+  | Binop ((Neq|Eq|Gte|Gt|Lte|Lt) as op, e1, e2) ->
+      let nop = begin match op with
+      | Eq   -> Neq
+      | Neq  -> Eq
+      | Lt   -> Gte
+      | Lte  -> Gt
+      | Gt   -> Lte
+      | Gte  -> Lt
+      | _    -> assert(false)
+      end in
+      Some (Binop (nop, e1, e2))
+  | Simple (Constant (Nil| Int _|Fun_ref _|Array _))
+  | Binop ((Plus|Sub|Mult|Div|Mod), _, _)
+  | Binop ((And|Or), _, _)  (* TODO *)
+  | Unop (Neg, _)
+  | Array_index _
+  | Array_length _ -> None
+
 type scope_annotation =
   | ExactScope of VarSet.t
   | AtLeastScope of VarSet.t

--- a/lexer.mll
+++ b/lexer.mll
@@ -9,7 +9,7 @@ let keyword_table = [
   "goto", GOTO;
   "print", PRINT;
   "assert", ASSERT;
-  "osr", OSR;
+  "assumption", ASSUMPTION;
   "stop", STOP;
   "read", READ;
   "drop", DROP;

--- a/ott.ml
+++ b/ott.ml
@@ -47,7 +47,7 @@ let disassemble_instrs buf (instrs : instructions) =
         let label = if String.length label = 1 then "l"^label else label in
         pr buf "%s : " label in
       begin match[@warning "-4"] instrs.(pc) with
-      | Label _ | Osr _ | Comment _ ->
+      | Label _ | Assumption _ | Comment _ ->
         ()
       | _ ->
         if needs_label then print_default_label ()
@@ -100,10 +100,10 @@ let disassemble_instrs buf (instrs : instructions) =
       | Read var                        ->
         pr buf " read %s\n" var;
         dump_next_instr ()
-      | Osr {label; cond; target={func; version; pos}; varmap; frame_maps} ->
+      | Assumption {label; guards; target={func; version; pos}; varmap; extra_frames} ->
         print_label label;
         let dump_var buf = function
-          | Osr_var (x, e)     -> pr buf "%s = %a" x dump_expr e
+          | x, e     -> pr buf "%s = %a" x dump_expr e
         in
         let dump_frame buf {cont_pos={func; version; pos}; cont_res; varmap} =
           pr buf "(%s, %s, %s) [%s = $, %a]"
@@ -111,11 +111,11 @@ let disassemble_instrs buf (instrs : instructions) =
             cont_res
             (dump_comma_separated dump_var) varmap
         in
-        pr buf "osr %a , (%s, %s, %s) [%a], %a\n"
-          (dump_comma_separated dump_expr) cond
+        pr buf "assumption %a with (%s, %s, %s) [%a], %a\n"
+          (dump_comma_separated dump_expr) guards
           func version pos
           (dump_comma_separated dump_var) varmap
-          (dump_comma_separated dump_frame) frame_maps;
+          (dump_comma_separated dump_frame) extra_frames;
         dump_next_instr ()
       | Comment str                     ->
         dump_instr buf (pc+1) line needs_label

--- a/parser.messages
+++ b/parser.messages
@@ -128,7 +128,7 @@ Parsing an instruction, we parsed an identifier so far (variable or label).
 - if this is a label declaration, we expect a semicolon: "<label>:"
 - if this is an assignment, we expect a left arrow: "<var> <- <expression>"
 
-program: OSR IDENTIFIER LBRACKET RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET RBRACKET COMMA LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET RBRACKET COMMA LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
 ##
 ## Ends in an error in state: 112.
 ##
@@ -142,14 +142,14 @@ There was an error parsing the variable map of an extra frame. The extra
 frame varmap syntax is "[var x = $, ...]"
 Note that the first variable binding in the environment mapping needs to
 capture the result register "$".
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR IDENTIFIER LBRACKET RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET RBRACKET COMMA TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET RBRACKET COMMA TRIPLE_DOT 
 ##
 ## Ends in an error in state: 104.
 ##
@@ -160,130 +160,130 @@ program: OSR IDENTIFIER LBRACKET RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COM
 ##
 
 There was an error parsing the specification of an extra frame. The extra
-frame syntax is "(func_label, vers_label, osr_label) [var x = $, ...]"
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+frame syntax is "(func_label, vers_label, label) [var x = $, ...]"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN LBRACKET TRIPLE_DOT 
 ##
 ## Ends in an error in state: 95.
 ##
-## osr_map -> LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE COMMA ]
+## varmap -> LBRACKET . loption(separated_nonempty_list(COMMA,osr_def)) RBRACKET [ NEWLINE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACKET 
 ##
 
 There was an error parsing the specification of the new environment of an
-osr instruction. The specification is a comma-separated list of terms of the form
+assumption instruction. The specification is a comma-separated list of terms of the form
 "var x = e" (where "e" is an expression).
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET NIL RBRACKET LPAREN IDENTIFIER COMMA IDENTIFIER COMMA IDENTIFIER RPAREN TRIPLE_DOT 
 ##
 ## Ends in an error in state: 94.
 ##
-## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . osr_map list(preceded(COMMA,osr_frame)) [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN . varmap list(preceded(COMMA,osr_frame)) [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN 
 ##
 
-After "osr [...] (...) " we expect the specification of the new environment.
+After "assumption [...] (...) " we expect the specification of the new environment.
 It is a square bracket enclosed, comma-separated list
 of terms of the form "var x = e" (where "e" is an expression).
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
 
-program: OSR IDENTIFIER LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET NIL RBRACKET LPAREN TRIPLE_DOT 
 ##
 ## Ends in an error in state: 88.
 ##
-## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN osr_map list(preceded(COMMA,osr_frame)) [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN . label COMMA label COMMA label RPAREN varmap list(preceded(COMMA,osr_frame)) [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN 
 ##
 
-Parsing an osr instruction, there is an error with the syntax of the target
+Parsing an assumption instruction, there is an error with the syntax of the target
 location "(function, version, label)".
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR IDENTIFIER LBRACKET NIL RBRACKET TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET NIL RBRACKET TRIPLE_DOT 
 ##
 ## Ends in an error in state: 87.
 ##
-## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN osr_map list(preceded(COMMA,osr_frame)) [ NEWLINE ]
+## instruction -> OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET . LPAREN label COMMA label COMMA label RPAREN varmap list(preceded(COMMA,osr_frame)) [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET 
 ##
 
-Parsing an osr instruction, we parsed "osr l [<expr> ...]", and are
+Parsing an assumption instruction, we parsed "assumption l [<expr> ...]", and are
 now expecting a target location "(function, version, label)".
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR IDENTIFIER LBRACKET TRIPLE_DOT 
+program: ASSUMPTION IDENTIFIER LBRACKET TRIPLE_DOT 
 ##
 ## Ends in an error in state: 84.
 ##
-## instruction -> OSR label LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN osr_map list(preceded(COMMA,osr_frame)) [ NEWLINE ]
+## instruction -> OSR label LBRACKET . loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN varmap list(preceded(COMMA,osr_frame)) [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR label LBRACKET 
 ##
 
-Parsing an osr instruction, there was an error parsing the list of conditions.
+Parsing an assumption instruction, there was an error parsing the list of conditions.
 Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
-program: OSR TRIPLE_DOT 
+program: ASSUMPTION TRIPLE_DOT 
 ##
 ## Ends in an error in state: 81.
 ##
-## instruction -> OSR . label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN osr_map list(preceded(COMMA,osr_frame)) [ NEWLINE ]
+## instruction -> OSR . label LBRACKET loption(separated_nonempty_list(COMMA,expression)) RBRACKET LPAREN label COMMA label COMMA label RPAREN varmap list(preceded(COMMA,osr_frame)) [ NEWLINE ]
 ##
 ## The known suffix of the stack is as follows:
 ## OSR 
 ##
 
-Parsing an osr instruction, we parsed "osr", and are now expecting a bracket
+Parsing an assumption instruction, we parsed "assumption", and are now expecting a bracket
 enclosed list of conditions. Conditions are expressions like "(x == 2)".
-The complete instruction syntax is "osr <label> [<conditions>] <frame> <extra_frame>*",
-where <frame> is "(func_label, vers_label, osr_label) [<osr_map>*]"
-and <extra_frame> is "(func_label, vers_label, osr_label) [var res = $, <osr_map>*]"
-and <osr_map> is "var x = exp"
+The complete instruction syntax is "assumption <label> [<conditions>] <frame> <extra_frame>*",
+where <frame> is "(func_label, vers_label, label) [<varmap>*]"
+and <extra_frame> is "(func_label, vers_label, label) [var res = $, <varmap>*]"
+and <varmap> is "var x = exp"
 For example,
-"osr l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
+"assumption l [(a==1)] (Main,optimized,l2) [var x = e, var y = y, var z], (f,v,l) [var y = $, var z = (1+x)]".
 
 program: LBRACE IDENTIFIER COMMA STOP 
 ##

--- a/parser.mly
+++ b/parser.mly
@@ -6,7 +6,7 @@
 %token DOUBLE_EQUAL NOT_EQUAL LT LTE GT GTE PLUS MINUS TIMES DIVIDE MOD DOUBLE_AMP DOUBLE_PIPE BANG
 %token LPAREN RPAREN LBRACKET RBRACKET LBRACE RBRACE
 %token COLON EQUAL LEFTARROW TRIPLE_DOT COMMA DOLLAR
-%token VAR BRANCH GOTO PRINT ASSERT OSR STOP READ DROP RETURN CALL VERSION FUNCTION
+%token VAR BRANCH GOTO PRINT ASSERT ASSUMPTION STOP READ DROP RETURN CALL VERSION FUNCTION
 %token ARRAY LENGTH
 %token<string> COMMENT
 %token NEWLINE
@@ -109,10 +109,10 @@ var_def:
 | VAR x=variable EQUAL e=expression { (x, e) }
 | VAR x=variable { (x, Simple (Constant Nil)) }
 
-osr_def: d=var_def { let (x, e) = d in Osr_var (x, e) }
-osr_map: LBRACKET map=separated_list(COMMA, osr_def) RBRACKET { map }
-osr_frame:
-  | LPAREN func=label COMMA version=label COMMA pos=label RPAREN LBRACKET VAR cont_res=variable EQUAL DOLLAR varmap=list(preceded(COMMA, osr_def)) RBRACKET
+varmap_entry: d=var_def { let (x, e) = d in (x, e) }
+varmap: LBRACKET map=separated_list(COMMA, varmap_entry) RBRACKET { map }
+extra_frame:
+  | LPAREN func=label COMMA version=label COMMA pos=label RPAREN LBRACKET VAR cont_res=variable EQUAL DOLLAR varmap=list(preceded(COMMA, varmap_entry)) RBRACKET
   { {varmap; cont_pos={func; version; pos}; cont_res} }
 
 instruction:
@@ -145,13 +145,13 @@ instruction:
   { Print e }
 | ASSERT e=expression
   { Assert e }
-| OSR
+| ASSUMPTION
   label=label
-  LBRACKET cond=separated_list(COMMA, expression) RBRACKET
+  LBRACKET guards=separated_list(COMMA, expression) RBRACKET
   LPAREN func=label COMMA version=label COMMA pos=label RPAREN
-  top=osr_map
-  frames=list(preceded(COMMA, osr_frame))
-  { Osr {label; cond; target= {func; version; pos}; varmap=top; frame_maps=frames} }
+  top=varmap
+  frames=list(preceded(COMMA, extra_frame))
+  { Assumption {label; guards; target= {func; version; pos}; varmap=top; extra_frames=frames} }
 | STOP e=expression
   { Stop e }
 | s=COMMENT

--- a/sourir.ml
+++ b/sourir.ml
@@ -70,7 +70,7 @@ let () =
     | Check.FunctionDoesNotExist f' ->
       Printf.eprintf "called function %s does not exist\n" f';
     | Check.VersionDoesNotExist (f', v') ->
-      Printf.eprintf "osr target %s %s does not exist\n" f' v';
+      Printf.eprintf "checkpoint target %s %s does not exist\n" f' v';
     | Check.InvalidNumArgs pc ->
       Printf.eprintf "at line %d: invalid number of arguments\n" (pc+1);
     | Check.InvalidArgument (pc, expression) ->
@@ -79,8 +79,8 @@ let () =
       Printf.eprintf "label %s does not exist\n" l;
     | Instr.Unbound_label (BranchLabel l) ->
       Printf.eprintf "label $%s does not exist\n" l;
-    | Instr.Unbound_osr_label l ->
-      Printf.eprintf "osr target %s does not exist\n" l;
+    | Instr.Unbound_bailout_target l ->
+      Printf.eprintf "checkpoint target %s does not exist\n" l;
     | Check.BranchLabelReused pc ->
       Printf.eprintf "label at line %d is used more than once\n" (pc+1);
     | Check.FallthroughLabel pc ->

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -12,7 +12,7 @@ function ncores {
   fi
 }
 
-export OPTS="prune\nprune_no_hoist\nhoist_guards\nconst_fold\nhoist_assign\nhoist_drop\nmin_live\ninline_small\ninline_med"
+export OPTS="prune_false\nprune_true\nprune_false_no_hoist\nhoist_guards\nconst_fold\nhoist_assign\nhoist_drop\nmin_live\ninline_small\ninline_med"
 export INPUTS="0\n1\n3\nnil\ntrue\nfalse"
 
 # Move into examples directory

--- a/test_examples.sh
+++ b/test_examples.sh
@@ -12,7 +12,7 @@ function ncores {
   fi
 }
 
-export OPTS="prune\nprune_no_hoist\nhoist_osr\nconst_fold\nhoist_assign\nhoist_drop\nmin_live\ninline_small\ninline_med"
+export OPTS="prune\nprune_no_hoist\nhoist_guards\nconst_fold\nhoist_assign\nhoist_drop\nmin_live\ninline_small\ninline_med"
 export INPUTS="0\n1\n3\nnil\ntrue\nfalse"
 
 # Move into examples directory

--- a/tests.ml
+++ b/tests.ml
@@ -417,7 +417,7 @@ let test_branch_pruning_exp prog expected =
   let open Transform in
   let prog = try_opt (as_opt_program Transform_assumption.insert_checkpoints) prog in
   let prune = try_opt (combine_opt
-                         [branch_prune;
+                         [branch_prune_false;
                           (as_opt_function Transform_assumption.hoist_assumption);
                           cleanup_all;]) in
   let prog2 = { prog with main = prune prog.main } in
@@ -429,7 +429,7 @@ let test_branch_pruning prog deopt =
   let open Eval in
   let open Transform in
   let prog = try_opt (as_opt_program Transform_assumption.insert_checkpoints) prog in
-  let prog2 = { prog with main = try_opt branch_prune prog.main } in
+  let prog2 = { prog with main = try_opt branch_prune_false prog.main } in
   let res1 = Eval.run_forever no_input prog in
   let res2 = Eval.run_forever no_input prog2 in
   assert_equal res1.trace res2.trace;

--- a/transform.ml
+++ b/transform.ml
@@ -105,7 +105,7 @@ exception UnknownOptimization of string
 
 let all_opts = ["prune";
                 "prune_no_hoist";
-                "hoist_osr";
+                "hoist_guards";
                 "const_fold";
                 "hoist_assign";
                 "hoist_drop";
@@ -128,7 +128,7 @@ let optimize (opts : string list) (prog : program) : program option =
       as_opt_program branch_prune_no_hoist
     | "prune" ->
       as_opt_program branch_prune
-    | "hoist_osr" ->
+    | "hoist_guards" ->
       as_opt_program (as_opt_function Transform_assumption.hoist_assumption)
     | "inline_max" ->
       Transform_inline.inline ()
@@ -146,7 +146,7 @@ let optimize (opts : string list) (prog : program) : program option =
     combine_opt [
         (as_opt_program Transform_assumption.insert_checkpoints);
         optimizer;
-        Transform_assumption.remove_empty_osr;
+        Transform_assumption.remove_empty_checkpoints;
         optimizer;
       ]
   in

--- a/transform_assumption.ml
+++ b/transform_assumption.ml
@@ -3,10 +3,10 @@ open Types
 open Transform_utils
 
 (* Inserts checkpoints at all program points
- * A checkpoint is a well-formed osr point and a matching label.
+ * A checkpoint is a well-formed checkpoint and a matching label.
  * For example:
  *   checkpoint_1:
- *     osr [] (func, version, checkpoint_1) [mut x = &x]
+ *     assumption [] (func, version, checkpoint_1) [mut x = &x]
  * Initially the checkpoint is self referential (ie. its target is
  * the label right above. Insert assumption makes use of this property
  * to create a new version where the checkpoints are in sync.
@@ -16,7 +16,7 @@ let insert_checkpoints (func:afunction) =
   let instrs = version.instrs in
 
   (* Can only insert checkpoints into an unoptimized function *)
-  if has_osr instrs then None else
+  if has_checkpoints instrs then None else
 
   let inp = Analysis.as_analysis_input func version in
   let scope = Scope.infer inp in
@@ -27,18 +27,18 @@ let insert_checkpoints (func:afunction) =
       | DeadScope -> Unchanged
       | Scope scope ->
         let vars = VarSet.elements scope in
-        let osr = List.map (fun x -> Osr_var (x, (Simple (Var x)))) vars in
+        let varmap = List.map (fun x -> x, (Simple (Var x))) vars in
         let target = {
           func=func.name;
           version=version.label;
           pos=checkpoint_label pc;
         } in
-        InsertBefore [Osr {label=checkpoint_label pc; cond=[]; target; varmap=osr; frame_maps=[]};]
+        InsertBefore [Assumption {label=checkpoint_label pc; guards=[]; target; varmap; extra_frames=[]};]
     in
     match[@warning "-4"] instrs.(pc) with
     | Label _ | Comment _ ->
         Unchanged
-    | Osr _ -> assert false
+    | Assumption _ -> assert false
     | _ -> create_checkpoint pc
   in
   let baseline = change_instrs transform inp in
@@ -57,25 +57,25 @@ end
 module TargetSet = Set.Make(LabelTarget)
 
 (* Removes all empty checkpoints with no incoming references *)
-let remove_empty_osr : opt_prog = fun prog ->
+let remove_empty_checkpoints : opt_prog = fun prog ->
   let get_targets = function[@warning "-4"]
-    | Osr {target; cond; frame_maps} when cond <> [] ->
+    | Assumption {target; guards; extra_frames} when guards <> [] ->
       let add tgs {cont_pos} = TargetSet.union tgs (TargetSet.singleton cont_pos) in
-      List.fold_left add (TargetSet.singleton target) frame_maps
+      List.fold_left add (TargetSet.singleton target) extra_frames
     | _ -> TargetSet.empty
   in
   let extract how what =
     let add tgs e = TargetSet.union tgs (how e) in
     List.fold_left add TargetSet.empty what
   in
-  (* Collect the targets (including the extra frames continuations) of all non empty osrs *)
+  (* Collect the targets (including the extra frames continuations) of all non empty checkpoints *)
   let used =
     extract (fun (f : afunction) ->
       extract (fun (v : version) ->
         extract get_targets (Array.to_list v.instrs)) f.body) (prog.main::prog.functions)
   in
 
-  (* Remove all empty and unused osr instructions in all versions *)
+  (* Remove all empty and unused assumption instructions in all versions *)
   let changed = ref false in
 
   let prog' =
@@ -86,7 +86,7 @@ let remove_empty_osr : opt_prog = fun prog ->
           let transform pc =
             let target pos = { func = func.name; version = version.label; pos = pos } in
             match[@warning "-4"] inp.instrs.(pc) with
-            | Osr {cond; label} when cond = [] && not (TargetSet.mem (target label) used) -> Remove 1
+            | Assumption {guards; label} when guards = [] && not (TargetSet.mem (target label) used) -> Remove 1
             | _ -> Unchanged
           in
           match change_instrs transform inp with
@@ -106,25 +106,25 @@ let remove_empty_osr : opt_prog = fun prog ->
   then Some prog'
   else None
 
-(* Inserts the assumption that osr_condition is false at position pc.
+(* Inserts the assumption that guards is false at position pc.
  * The approach is to
  * 1. Create a new version. This is a copy of the current one where all
- *    the osr targets point one version down (ie. to the current one).
+ *    the checkpoint targets point one version down (ie. to the current one).
  * 2. Starting from pc walk up the cfg and find the earliest possible
- *    checkpoint for the osr_condition. Branch targets are blocking as
- *    are instructions which interfere with the osr_condition. The
- *    condition has to be added to an existing osr instruction (see
+ *    checkpoint for the guard. Branch targets are blocking as
+ *    are instructions which interfere with the guard. The
+ *    condition has to be added to an existing assumption instruction (see
  *    insert_checkpoints above). *)
-let insert_assumption ?(hoist=false) (func : afunction) osr_cond pc : version option =
-  (* This takes the active version and duplicates it. Osr targets are
+let insert_assumption ?(hoist=false) (func : afunction) cond pc : version option =
+  (* This takes the active version and duplicates it. Checkpoint targets are
    * updated to point to the currently active version *)
   let next_version (func:afunction) =
     let cur_version = Instr.active_version func in
     let transform pc =
       match[@warning "-4"] cur_version.instrs.(pc) with
-      | Osr {label; cond; target; varmap; frame_maps} ->
+      | Assumption {label; guards; target; varmap; extra_frames} ->
         let target = {target with version = cur_version.label} in
-        Replace [Osr {label; cond; target; varmap; frame_maps}]
+        Replace [Assumption {label; guards; target; varmap; extra_frames}]
       | _ -> Unchanged
     in
     let inp = Analysis.as_analysis_input func cur_version in
@@ -136,33 +136,33 @@ let insert_assumption ?(hoist=false) (func : afunction) osr_cond pc : version op
   let version = next_version func in
   let instrs = version.instrs in
   let preds = Analysis.predecessors version.instrs in
-  (* Finds the highest up osr checkpoint in that basic block where the
+  (* Finds the highest up checkpoint in that basic block where the
    * assumption can be placed. *)
-  let rec find_candidate_osr cond_vars pc acc =
+  let rec find_candidate_checkpoint cond_vars pc acc =
     if pc < 0 then acc else
     match[@warning "-4"] instrs.(pc) with
-    | Osr _ ->
+    | Assumption _ ->
       if hoist
-      then find_candidate_osr cond_vars (pc-1) (Some pc)
+      then find_candidate_checkpoint cond_vars (pc-1) (Some pc)
       else Some pc
     | Label _ ->
       begin match[@warning "-4"] preds.(pc) with
-      | [pred] -> find_candidate_osr cond_vars pred acc
+      | [pred] -> find_candidate_checkpoint cond_vars pred acc
       | _ -> acc
       end
     | _ ->
       assert (preds.(pc) = [pc-1] || preds.(pc) = []);
-      if preds.(pc) <> [] && Instr.independent instrs.(pc) osr_cond
-      then find_candidate_osr cond_vars (pc-1) acc
+      if preds.(pc) <> [] && Instr.independent instrs.(pc) cond
+      then find_candidate_checkpoint cond_vars (pc-1) acc
       else acc
   in
-  let osr_vars = expr_vars osr_cond in
-  begin match find_candidate_osr osr_vars (pc-1) None with
+  let used_vars = expr_vars cond in
+  begin match find_candidate_checkpoint used_vars (pc-1) None with
   | None -> None
   | Some pc ->
     begin match[@warning "-4"] instrs.(pc) with
-    | Osr {label; cond; target; varmap; frame_maps} ->
-      instrs.(pc) <- Osr {label; cond=osr_cond::cond; target; varmap; frame_maps};
+    | Assumption {label; guards; target; varmap; extra_frames} ->
+      instrs.(pc) <- Assumption {label; guards=cond::guards; target; varmap; extra_frames};
       Some { version with instrs }
     | _ -> assert (false)
     end
@@ -170,36 +170,36 @@ let insert_assumption ?(hoist=false) (func : afunction) osr_cond pc : version op
 
 (* hoist_assumption tries to hoist assumptions out of loops.
  *
- * Like in insert_assumption the strategy is to find the earliest possible osr
+ * Like in insert_assumption the strategy is to find the earliest possible checkpoint
  * instruction where a condition can be moved to and which ensures that the
  * condition still holds for the original position. In the most trivial case
  * this can be the following example
  *
- *   osr [x==1] ...
+ *   assumption [x==1] ...
  *   print x
- *   osr [x==2] ...
+ *   assumption [x==2] ...
  *   ===============>
- *   osr [x==1,x==2] ...
+ *   assumption [x==1,x==2] ...
  *   print x
- *   osr []
+ *   assumption []
  *
  * The interesting case is where hoist_assumption is able to move an assumption
  * out of a loop:
  *
- *    osr [] ...
+ *    assumption [] ...
  *    goto loop
  *   loop:
  *    print (x+1)
- *    osr [x==1] ...
+ *    assumption [x==1] ...
  *    print x
  *    branch _ loop cont
  *   cont:
  *   ===================>
- *    osr [x==1] ...
+ *    assumption [x==1] ...
  *    goto loop
  *   loop:
  *    print (x+1)
- *    osr [] ...
+ *    assumption [] ...
  *    print x
  *    branch _ loop cont
  *   cont:
@@ -220,64 +220,64 @@ let hoist_assumption : transform_instructions = fun ({instrs; _} as inp) ->
   let available = Analysis.valid_assumptions inp in
   let preds = Analysis.predecessors instrs in
   let dominates = Analysis.dominates inp in
-  let rec find_osrs pc acc =
+  let rec find_guards pc acc =
     if pc = Array.length instrs then acc else
     match[@warning "-4"] instrs.(pc) with
-    | Osr {cond} when cond <> [] -> find_osrs (pc+1) (pc::acc)
-    | _ -> find_osrs (pc+1) acc
+    | Assumption {guards} when guards <> [] -> find_guards (pc+1) (pc::acc)
+    | _ -> find_guards (pc+1) acc
   in
-  let osrs = find_osrs 0 [] in
+  let guards = find_guards 0 [] in
 
-  (* Finds the highest up osr checkpoint that dominates this instruction
+  (* Finds the highest up assumption checkpoint that dominates this instruction
    * and where the intermediate instructions don't change the condition.
    * For multi-predecessor instruction we can push the assumption to a
    * unique dominator if the assumption is available on all other
    * predecessors. *)
-  let rec find_candidate_osr osr_cond cond_vars pc acc =
+  let rec find_candidate_checkpoint cond cond_vars pc acc =
     if pc < 0 then acc else
     match[@warning "-4"] instrs.(pc) with
-    | Osr _ -> find_candidate_osr osr_cond cond_vars (pc-1) (Some pc)
+    | Assumption _ -> find_candidate_checkpoint cond cond_vars (pc-1) (Some pc)
     | Label _ ->
       let doms, rest = List.partition (fun pc' -> dominates pc' pc) preds.(pc) in
       begin match doms with
       | [dom] ->
         let all_guarded = List.for_all (fun pc' ->
             let available = available pc' in
-            Analysis.ExpressionSet.mem osr_cond available
+            Analysis.ExpressionSet.mem cond available
           ) rest in
         if all_guarded
-        then find_candidate_osr osr_cond cond_vars dom acc
+        then find_candidate_checkpoint cond cond_vars dom acc
         else acc
       | _ -> acc
       end
     | _ ->
       assert (preds.(pc) = [pc-1] || preds.(pc) == []);
-      if preds.(pc) <> [] && Instr.independent instrs.(pc) osr_cond
-      then find_candidate_osr osr_cond cond_vars (pc-1) acc
+      if preds.(pc) <> [] && Instr.independent instrs.(pc) cond
+      then find_candidate_checkpoint cond cond_vars (pc-1) acc
       else acc
   in
 
   let changed = ref false in
-  let push_osr pc =
+  let push_guards pc =
     match[@warning "-4"] instrs.(pc) with
-    | Osr {label; cond; target; varmap; frame_maps} ->
+    | Assumption {label; guards; target; varmap; extra_frames} ->
       let try_push c =
         let cond_vars = expr_vars c in
-        begin match find_candidate_osr c cond_vars (pc-1) None with
+        begin match find_candidate_checkpoint c cond_vars (pc-1) None with
         | None -> true
         | Some pc' ->
           changed := true;
           begin match[@warning "-4"] instrs.(pc') with
-          | Osr {label; cond; target; varmap; frame_maps} ->
-            instrs.(pc') <- Osr {label; cond = c::cond; target; varmap; frame_maps}
+          | Assumption {label; guards; target; varmap; extra_frames} ->
+            instrs.(pc') <- Assumption {label; guards = c::guards; target; varmap; extra_frames}
           | _ -> assert (false)
           end;
           false
         end
       in
-      let remaining = List.filter try_push cond in
-      instrs.(pc) <- Osr {label; cond=remaining; target; varmap; frame_maps}
+      let remaining = List.filter try_push guards in
+      instrs.(pc) <- Assumption {label; guards=remaining; target; varmap; extra_frames}
     | _ -> assert (false)
   in
-  List.iter push_osr osrs;
+  List.iter push_guards guards;
   if !changed then Some instrs else None

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -91,7 +91,7 @@ let const_fold : transform_instructions = fun {formals; instrs} ->
            arrays *)
         VarMap.add x Unknown cur
       | ( Branch _ | Label _ | Goto _ | Return _
-        | Print _ | Assert _ | Stop _ | Osr _ | Comment _)
+        | Print _ | Assert _ | Stop _ | Assumption _ | Comment _)
         as instr ->
         begin
           assert (VarSet.is_empty (changed_vars instr));

--- a/transform_fix.ml
+++ b/transform_fix.ml
@@ -10,7 +10,7 @@ let remove_falltrough ({instrs} as inp : analysis_input) =
       | Decl_var _ | Decl_array _
       | Assign _ | Array_assign _
       | Drop _ | Read _ | Call _ | Label _
-      | Comment _ | Osr _ | Print _ | Assert _ -> true
+      | Comment _ | Assumption _ | Print _ | Assert _ -> true
       | Stop _ | Return _ | Goto _ | Branch _ -> false
     in
     match[@warning "-4"] instrs.(pc) with

--- a/transform_prune.ml
+++ b/transform_prune.ml
@@ -28,6 +28,9 @@ let branch_prune : transform_instructions = fun input ->
   let rec find_candidates pc branches =
     if pc = Array.length input.instrs then branches else
     match[@warning "-4"] input.instrs.(pc) with
+    | Branch (Simple (Constant (Bool true)),  l, _)
+    | Branch (Simple (Constant (Bool false)), _, l) ->
+      find_candidates (pc+1) ((pc,l)::branches)
     | Branch (e, l1, l2) ->
       if Analysis.ExpressionSet.mem e (assumptions pc)
       then find_candidates (pc+1) ((pc,l1)::branches)

--- a/transform_prune.ml
+++ b/transform_prune.ml
@@ -23,8 +23,8 @@ let branch_prune : transform_instructions = fun input ->
     if pc = Array.length input.instrs then branches else
     match[@warning "-4"] input.instrs.(pc) with
     | Branch (e, l1, l2) when Analysis.ExpressionSet.mem e (assumptions pc) ->
-      (* This branch has to go to l2! *)
-      find_candidates (pc+1) ((pc,l2)::branches)
+      (* This branch has to go to l1! *)
+      find_candidates (pc+1) ((pc,l1)::branches)
     | _ ->
       find_candidates (pc+1) branches
   in

--- a/transform_prune.ml
+++ b/transform_prune.ml
@@ -2,14 +2,20 @@ open Instr
 open Types
 open Transform_utils
 
-let insert_branch_pruning_assumption ?(hoist=true) (func : afunction) : version option =
+let insert_branch_pruning_assumption ?(hoist=true) ?(assume=true) (func : afunction) : version option =
   let version = Instr.active_version func in
   let instrs = version.instrs in
   (* Finds the first branch instruction in the stream *)
   let rec find_branch pc =
     if pc = Array.length instrs then None else
     match[@warning "-4"] instrs.(pc) with
-    | Branch (exp, l1, l2) -> Some (pc, exp)
+    | Branch (exp, l1, l2) ->
+        if assume
+        then Some (pc, exp)
+        else begin match negate exp with
+        | Some nexp -> Some (pc, nexp)
+        | None -> find_branch (pc+1)
+        end
     | _ -> find_branch (pc+1)
   in
   match find_branch 0 with
@@ -22,9 +28,15 @@ let branch_prune : transform_instructions = fun input ->
   let rec find_candidates pc branches =
     if pc = Array.length input.instrs then branches else
     match[@warning "-4"] input.instrs.(pc) with
-    | Branch (e, l1, l2) when Analysis.ExpressionSet.mem e (assumptions pc) ->
-      (* This branch has to go to l1! *)
-      find_candidates (pc+1) ((pc,l1)::branches)
+    | Branch (e, l1, l2) ->
+      if Analysis.ExpressionSet.mem e (assumptions pc)
+      then find_candidates (pc+1) ((pc,l1)::branches)
+      else begin match[@warning "-4"] negate e with
+      | Some ne when Analysis.ExpressionSet.mem ne (assumptions pc) ->
+        find_candidates (pc+1) ((pc,l2)::branches)
+      | _ ->
+        find_candidates (pc+1) branches
+      end
     | _ ->
       find_candidates (pc+1) branches
   in


### PR DESCRIPTION
Guard (like osr) is to narrow. it goes in the wrong direction. Our
approach is not "let's optimize, then add guards to safe us" but rather
"lets assumpe something then see what optimizations follow".

Also bailing out if any of the conditions is true (rather than if any of
them is false) seems counter intuitive for most people. So lets bite the
bullet and switch it.

My proposal is:

in sourir:
assumption l [guard,...] (t2..) [x=x,...], (t2...) [x...]

in ott:
l: assumption [guard,...] with (t2..) [x=x,...], (t2...) [x...]

This is the intended naming scheme:

* the whole thing is a checkpoint
* l is the label of the checkpoint
* [guard,...] are the guards or assumptions. the assumption is *positive*, we bail out if the guard *fails*  (new)
* (t2..) is the bailout target
* [x=x,...] is the variable map or environment map
* the rest are the extra frames, each extra frame again has a bailout target and a varmap