### PR TITLE
don't rely on osr after call for extra_frames in inlinee

### DIFF
--- a/check.ml
+++ b/check.ml
@@ -99,7 +99,7 @@ let well_formed prog =
       let check_varmap = List.iter check_varmap_entry in
       let check_extra_frame {varmap} = check_varmap varmap in
       match instr with
-      | Call (_x, f, es) ->
+      | Call (_, _x, f, es) ->
         (check_expr f;
          List.iter check_arg es)
       | Decl_var (_, e)
@@ -130,7 +130,7 @@ let well_formed prog =
     (* Check correctness of calls and osrs *)
     let check_instr pc instr =
       match[@warning "-4"] instr with
-      | Call (x, f, exs) ->
+      | Call (_, x, f, exs) ->
         (* if it's a static call check that the function exists and if the
          * actual arguments are compatible with the formals *)
         begin match[@warning "-4"] f with

--- a/disasm.ml
+++ b/disasm.ml
@@ -41,10 +41,10 @@ let disassemble_instrs buf ?(ott_compatible = false) ?(format_pc = no_line_numbe
     let dump_arg buf arg = dump_expr buf arg in
     format_pc buf pc;
     begin match instr with
-    | Call (var, f, args)               ->
+    | Call (l, var, f, args)          ->
       pr buf " call %s = "var;
       dump_expr buf f;
-      pr buf " (%a)" (dump_comma_separated dump_arg) args;
+      pr buf " (%a) %s" (dump_comma_separated dump_arg) args l;
     | Stop exp                        -> pr buf " stop %a" dump_expr exp
     | Return exp                      -> pr buf " return %a" dump_expr exp
     | Decl_var (var, exp)           -> pr buf " var %s = %a" var dump_expr exp

--- a/eval.ml
+++ b/eval.ml
@@ -285,7 +285,7 @@ let reduce conf =
   in
 
   match instruction conf with
-  | Call (x, f, args) ->
+  | Call (_, x, f, args) ->
     let f = eval conf f in
     let func = lookup_fun conf.program (get_fun f) in
     if List.length func.formals <> List.length args then raise InvalidNumArgs;

--- a/ott.ml
+++ b/ott.ml
@@ -47,14 +47,14 @@ let disassemble_instrs buf (instrs : instructions) =
         let label = if String.length label = 1 then "l"^label else label in
         pr buf "%s : " label in
       begin match[@warning "-4"] instrs.(pc) with
-      | Label _ | Assume _ | Comment _ ->
+      | Label _ | Call _ | Assume _ | Comment _ ->
         ()
       | _ ->
         if needs_label then print_default_label ()
       end;
       begin match instrs.(pc) with
-      | Call (var, f, args)               ->
-        pr buf " call %s = "var;
+      | Call (l, var, f, args)          ->
+        pr buf "%s : call %s = " l var;
         dump_expr buf f;
         pr buf " (%a)\n" (dump_comma_separated dump_arg) args;
         dump_next_instr ()

--- a/parser.mly
+++ b/parser.mly
@@ -17,6 +17,12 @@
 
 %{ open Instr
 
+let next_cont_label =
+  let cur = ref 0 in
+  fun () ->
+    cur := !cur + 1;
+    "__cont_"^string_of_int(!cur)
+
 let scope_annotation (mode, xs) =
   let xs = Instr.VarSet.of_list xs in
   match mode with
@@ -116,8 +122,10 @@ extra_frame:
   { {varmap; cont_pos={func; version; pos}; cont_res} }
 
 instruction:
+| CALL x=variable EQUAL f=expression LPAREN args=separated_list(COMMA, argument) RPAREN label=label
+  { Call (label, x, f, args) }
 | CALL x=variable EQUAL f=expression LPAREN args=separated_list(COMMA, argument) RPAREN
-  { Call (x, f, args) }
+  { Call (next_cont_label (), x, f, args) }
 | RETURN e=expression
   { Return e }
 | d=var_def { let (x, e) = d in Decl_var (x, e) }

--- a/tests.ml
+++ b/tests.ml
@@ -1064,11 +1064,11 @@ let do_test_const_fold_driver () =
   (* Propagating function references *)
   test {input|
     var f = 'foo
-    call x = f ()
+    call x = f () c1
    function foo ()
     return 42
   |input} {expect|
-    call x = 'foo ()
+    call x = 'foo () c1
    function foo ()
     return 42
   |expect};
@@ -1076,9 +1076,9 @@ let do_test_const_fold_driver () =
   test {input|
     var a = 1
     var b = 2
-    call w = 'f ((a + a))
-    call y = 'f (b)
-    call z = 'g (b)
+    call w = 'f ((a + a)) c1
+    call y = 'f (b) c2
+    call z = 'g (b) c3
    function f (var n)
     var a = (2 + 3)
     return a
@@ -1089,9 +1089,9 @@ let do_test_const_fold_driver () =
     m <- b
     return m
   |input} {expect|
-    call w = 'f (2)
-    call y = 'f (2)
-    call z = 'g (2)
+    call w = 'f (2) c1
+    call y = 'f (2) c2
+    call z = 'g (2) c3
    function f (var n)
     return 5
    function g (var m)

--- a/transform_constantfold.ml
+++ b/transform_constantfold.ml
@@ -78,7 +78,7 @@ let const_fold : transform_instructions = fun {formals; instrs} ->
         (* this case could be improved with approximation for arrays so
            that, eg., length(x) could be constant-folded *)
         VarMap.add x Unknown cur
-      | Call (x, _, _) as call ->
+      | Call (_, x, _, _) as call ->
         let mark_unknown x cur = VarMap.add x Unknown cur in
         cur
         |> VarSet.fold mark_unknown (changed_vars call)

--- a/transform_hoist.ml
+++ b/transform_hoist.ml
@@ -162,7 +162,7 @@ module Drop = struct
    *)
   let is_blocking var instr =
     match[@warning "-4"] instr with
-    | Call (x, _, _) when x = var -> true
+    | Call (_, x, _, _) when x = var -> true
     | _ -> VarSet.mem var (required_vars instr)
 
   let is_eliminating var instr =


### PR DESCRIPTION
add an implicit bailout label to call instruction, use that
one for bailout targets of extra frames.